### PR TITLE
INTERLOK-2658 Fixing (or at least ignoring) spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,7 @@ spotbugs {
   // We only care about "high priority" issues...
   reportLevel = "high"
   includeFilter = new File("$rootDir/gradle/spotbugs-filter.xml")
+  excludeFilter = new File("$rootDir/gradle/spotbugs-exclude.xml")
 }
 
 // disable spotbugsTests which checks our test code..

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+              xmlns="https://github.com/spotbugs/filter/3.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <!-- 
+    uri.equals(getRquestURL().toURI() != uri.toURL().equals(getRequestingURL())
+    AND we don't want to change behaviour.
+   -->
+  <Match>
+    <Class name="com.adaptris.core.http.apache.ApacheHttpProducer"/>
+    <Bug pattern="DMI_BLOCKING_METHODS_ON_URL" />
+  </Match>
+  <Match>
+    <Class name="com.adaptris.core.http.apache.ApacheHttpProducer$ApacheResourceTargetMatcher"/>
+    <Bug pattern="DMI_BLOCKING_METHODS_ON_URL" />
+  </Match>
+
+</FindBugsFilter>

--- a/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
@@ -8,6 +8,7 @@ import java.net.URI;
 
 import javax.validation.Valid;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -32,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Producer implementation that uses the Apache HTTP Client as the underlying transport.
- * 
+ *
  * @config apache-http-producer
  */
 @XStreamAlias("apache-http-producer")
@@ -77,7 +78,7 @@ public class ApacheHttpProducer extends HttpProducer {
 
   /**
    * Set how to handle the response.
-   * 
+   *
    * @param fac the factory; default is {@link PayloadResponseHandlerFactory}.
    */
   public void setResponseHandlerFactory(ResponseHandlerFactory fac) {
@@ -122,14 +123,14 @@ public class ApacheHttpProducer extends HttpProducer {
 
   /**
    * Do any further customisations.
-   * 
+   *
    * @param builder the builder
    * @return the builder.
    */
   protected HttpClientBuilder customise(HttpClientBuilder builder) throws Exception {
     return builder;
   }
-  
+
   private HttpRequestBase addData(AdaptrisMessage msg, HttpRequestBase base) throws IOException,
       CoreException {
     if (base instanceof HttpEntityEnclosingRequestBase) {
@@ -139,13 +140,13 @@ public class ApacheHttpProducer extends HttpProducer {
     return base;
   }
 
-  private class ApacheResourceTargetMatcher implements ResourceTargetMatcher {
+  protected class ApacheResourceTargetMatcher implements ResourceTargetMatcher {
 
     private URI uri;
     private String host;
     private int port;
 
-    ApacheResourceTargetMatcher(URI uri) {
+    protected ApacheResourceTargetMatcher(URI uri) {
       this.uri = uri;
       this.port = derivePort(uri);
       host = uri.getHost();
@@ -180,7 +181,13 @@ public class ApacheHttpProducer extends HttpProducer {
       boolean rc = false;
       try {
         if (target.getRequestingURL() == null) {
-          rc = host.equalsIgnoreCase(target.getRequestingHost()) && port == target.getRequestingPort();
+          rc = BooleanUtils.and(new boolean[]
+          {
+              host.equalsIgnoreCase(target.getRequestingHost()), port == target.getRequestingPort(),
+              // Do we need to check the scheme ? would you have different logins
+              // for https vs http ?
+              // uri.getScheme().equalsIgnoreCase(target.getRequestingScheme())
+          });
         }
         else {
           rc = uri.toURL().equals(target.getRequestingURL());

--- a/src/test/java/com/adaptris/core/http/apache/ApacheResourceTargetMatcherTest.java
+++ b/src/test/java/com/adaptris/core/http/apache/ApacheResourceTargetMatcherTest.java
@@ -1,0 +1,50 @@
+package com.adaptris.core.http.apache;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.adaptris.core.http.ResourceAuthenticator.ResourceTarget;
+
+public class ApacheResourceTargetMatcherTest extends ApacheHttpProducer {
+
+  @Test
+  public void testMatch_HTTP_URL() throws Exception {
+    String httpUrlExplicit = "http://localhost:80/path/to/index.html";
+    String httpUrlImplicit = "http://localhost/path/to/index.html";
+
+    ResourceTarget httpTarget = new ResourceTarget().withRequestingURL(new URL(httpUrlExplicit));
+    assertTrue(new ApacheResourceTargetMatcher(new URI(httpUrlExplicit)).matches(httpTarget));
+    assertTrue(new ApacheResourceTargetMatcher(new URI(httpUrlImplicit)).matches(httpTarget));
+
+    assertFalse(new ApacheResourceTargetMatcher(new URI(httpUrlImplicit))
+        .matches(new ResourceTarget().withRequestingURL(new URL("http://localhost/another/path"))));
+  }
+
+  @Test
+  public void testMatch_HTTPS_URL() throws Exception {
+    String httpsUrlExplicit = "https://localhost:443/path/to/index.html";
+    String httpsUrlImplicit = "https://localhost/path/to/index.html";
+    ResourceTarget httpsTarget = new ResourceTarget().withRequestingURL(new URL(httpsUrlExplicit));
+    assertTrue(new ApacheResourceTargetMatcher(new URI(httpsUrlExplicit)).matches(httpsTarget));
+    assertTrue(new ApacheResourceTargetMatcher(new URI(httpsUrlImplicit)).matches(httpsTarget));
+    assertFalse(new ApacheResourceTargetMatcher(new URI(httpsUrlImplicit))
+        .matches(new ResourceTarget().withRequestingURL(new URL("https://localhost/another/path"))));
+  }
+
+  @Test
+  public void testMatch_HostPortScheme() throws Exception {
+    String url = "http://localhost/path/to/index.html";
+    ApacheResourceTargetMatcher matcher = new ApacheResourceTargetMatcher(new URI(url));
+    assertTrue(matcher.matches(new ResourceTarget().withRequestingHost("localhost").withRequestingPort(80).withRequestingScheme("http")));
+    assertFalse(matcher
+        .matches(new ResourceTarget().withRequestingHost("localhost").withRequestingPort(8080).withRequestingScheme("http")));
+    assertFalse(matcher
+        .matches(new ResourceTarget().withRequestingHost("microsoft.com").withRequestingPort(80).withRequestingScheme("http")));
+  }
+
+}


### PR DESCRIPTION
- Made ApacheResourceTargetMatcher testable along with tests.

However, it turns out that `uri.equals(getRequestingURL().toURI()`  and `uri.toURL().equals(getRequestingURL())` don't behave the same way.  If we change ARTM to use the URI version; then the tests fail (line 22, line 34 ARTMTest).

So in the end to not change behaviour we turn off the spotbugs check.