### PR TITLE
INTERLOK-2682 Ensure we don't overwrite reply-metadata with the original

### DIFF
--- a/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
@@ -1,19 +1,15 @@
 package com.adaptris.core.http.apache;
 
 import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
-
 import javax.validation.Valid;
-
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -107,7 +103,6 @@ public class ApacheHttpProducer extends HttpProducer {
         addData(msg, getRequestHeaderProvider().addHeaders(msg, httpOperation));
         reply = httpclient.execute(httpOperation, responseHandlerFactory().createResponseHandler(this));
       }
-      copyHeaders(msg, reply);
     } catch (Exception e) {
       throw ExceptionHelper.wrapProduceException(e);
     }

--- a/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -2,12 +2,8 @@ package com.adaptris.core.http.apache;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
-
-import java.io.IOException;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -19,7 +15,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -317,12 +312,6 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
    */
   public void setIgnoreServerResponseCode(Boolean b) {
     ignoreServerResponseCode = b;
-  }
-
-  @SuppressWarnings("deprecation")
-  protected void copyHeaders(AdaptrisMessage src, AdaptrisMessage dest) throws IOException, CoreException {
-    dest.getObjectMetadata().putAll(src.getObjectMetadata());
-    dest.setMetadata(src.getMetadata());
   }
 
   public ContentTypeProvider getContentTypeProvider() {

--- a/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -542,7 +542,8 @@ public class ApacheHttpProducerTest extends ProducerCase {
   }
 
 
-  public void test_ReplyMetadataOvewritesOriginal() throws Exception {
+  // INTERLOK-2682
+  public void test_ReplyMetadataReplacesOriginal() throws Exception {
     MockMessageProducer mock = new MockMessageProducer();
     HttpConnection jc = createConnection();
     JettyMessageConsumer mc = createConsumer(URL_TO_POST_TO);


### PR DESCRIPTION
In the end, a 1 line change (i.e. removing copyHeaders()) which is redundant since this is handled as part of the RequestReplyProducerImpl behaviour; and also ensured by StandaloneRequestor.

Added tests to showcase the exception first, and then fix it.
