### PR TITLE
INTERLOK-3396 metadata-output overwrites the payload with blank

### DIFF
--- a/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -216,8 +216,6 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
    * <p>
    * If not explicitly configured will be a {@link DefaultClientBuilder} with its defaults.
    * </p>
-   *
-   * @param httpClientCustomiser a {@link HttpClientBuilderConfigurator} instance.
    */
   @Valid
   @AdvancedConfig

--- a/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -38,10 +38,10 @@ import com.adaptris.core.http.client.RequestHeaderProvider;
 import com.adaptris.core.http.client.RequestMethodProvider;
 import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.http.client.ResponseHeaderHandler;
-import com.adaptris.core.util.Args;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 /**
@@ -109,36 +109,117 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
     public abstract HttpRequestBase create(String url);
   }
 
+  /**
+   * The HTTP method.
+   * <p>
+   * The default is {@code POST}
+   * </p>
+   */
   @NotNull
   @AutoPopulated
   @Valid
+  @NonNull
+  @Getter
+  @Setter
   private RequestMethodProvider methodProvider;
 
+  /**
+   * The Content-Type header associated with the HTTP operation.
+   * <p>
+   * The default is {@code text/plain} based on the default from
+   * {@link ConfiguredContentTypeProvider}.
+   * </p>
+   *
+   */
   @NotNull
   @Valid
   @AutoPopulated
   @AdvancedConfig
+  @NonNull
+  @Getter
+  @Setter
   private ContentTypeProvider contentTypeProvider;
 
+  /**
+   * Specify how we handle headers from the HTTP response.
+   *
+   * <p>
+   * If not explicitly configured then the default is {@link DiscardResponseHeaders}
+   * </p>
+   */
   @AdvancedConfig
   @Valid
+  @NonNull
   @NotNull
   @AutoPopulated
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "discard response headers")
   private ResponseHeaderHandler<HttpResponse> responseHeaderHandler;
 
+  /**
+   * Any additional HTTP headers we wish to send with the request.
+   * <p>
+   * If not explicitly configured then the default is {@link NoOpRequestHeaders}
+   * </p>
+   *
+   */
   @AdvancedConfig
   @Valid
   @NotNull
   @AutoPopulated
+  @NonNull
+  @Getter
+  @Setter
   private RequestHeaderProvider<HttpRequestBase> requestHeaderProvider;
 
+  /**
+   * Control whether or not to ignore the server response code.
+   * <p>
+   * In some cases, you may wish to ignore any server response code (such as 500) as this may return
+   * meaningful data that you wish to use. If that's the case, make sure this flag is true. It
+   * defaults to false.
+   * </p>
+   * <p>
+   * In all cases the metadata key {@link CoreConstants#HTTP_PRODUCER_RESPONSE_CODE} is populated
+   * with the last server response.
+   * </p>
+   *
+   */
   @AdvancedConfig
   @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
   private Boolean ignoreServerResponseCode;
+  /**
+   * Set the authentication method to use for the HTTP request
+   * <p>
+   * If not explicitly configured then defaults to {@link NoAuthentication}.
+   * </p>
+   *
+   * @see ApacheRequestAuthenticator
+   * @see ConfiguredUsernamePassword
+   * @see MetadataUsernamePassword
+   * @see ConfiguredAuthorizationHeader
+   * @see MetadataAuthorizationHeader
+   */
   @Valid
+  @Getter
+  @Setter
   private HttpAuthenticator authenticator;
+  /**
+   * Customise the underlying Apache {@code HttpClientBuilder} before the request is made.
+   *
+   * <p>
+   * If not explicitly configured will be a {@link DefaultClientBuilder} with its defaults.
+   * </p>
+   *
+   * @param httpClientCustomiser a {@link HttpClientBuilderConfigurator} instance.
+   */
   @Valid
   @AdvancedConfig
+  @Getter
+  @Setter
   private HttpClientBuilderConfigurator clientConfig;
   /**
    * The ProduceDestination contains the url we will access.
@@ -180,99 +261,8 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
   }
 
 
-  /**
-   * Get the currently configured flag for ignoring server response code.
-   *
-   * @return true or false
-   * @see #setIgnoreServerResponseCode(Boolean)
-   */
-  public Boolean getIgnoreServerResponseCode() {
-    return ignoreServerResponseCode;
-  }
-
   protected boolean ignoreServerResponseCode() {
     return BooleanUtils.toBooleanDefaultIfNull(getIgnoreServerResponseCode(), false);
-  }
-
-  /**
-   * Set whether to ignore the server response code.
-   * <p>
-   * In some cases, you may wish to ignore any server response code (such as 500) as this may return meaningful data that you wish
-   * to use. If that's the case, make sure this flag is true. It defaults to false.
-   * </p>
-   * <p>
-   * In all cases the metadata key {@link CoreConstants#HTTP_PRODUCER_RESPONSE_CODE} is populated with the last server response.
-   * </p>
-   *
-   * @see CoreConstants#HTTP_PRODUCER_RESPONSE_CODE
-   * @param b true
-   */
-  public void setIgnoreServerResponseCode(Boolean b) {
-    ignoreServerResponseCode = b;
-  }
-
-  public ContentTypeProvider getContentTypeProvider() {
-    return contentTypeProvider;
-  }
-
-  /**
-   * Specify the Content-Type header associated with the HTTP operation.
-   *
-   * @param ctp
-   */
-  public void setContentTypeProvider(ContentTypeProvider ctp) {
-    contentTypeProvider = ctp;
-  }
-
-  public ResponseHeaderHandler<HttpResponse> getResponseHeaderHandler() {
-    return responseHeaderHandler;
-  }
-
-  /**
-   * Specify how we handle headers from the HTTP response.
-   *
-   * @param handler the handler, default is a {@link DiscardResponseHeaders}.
-   */
-  public void setResponseHeaderHandler(ResponseHeaderHandler<HttpResponse> handler) {
-    responseHeaderHandler = Args.notNull(handler, "ResponseHeaderHandler");
-  }
-
-  public RequestHeaderProvider<HttpRequestBase> getRequestHeaderProvider() {
-    return requestHeaderProvider;
-  }
-
-  /**
-   * Specify how we want to generate the initial set of HTTP Headers.
-   *
-   * @param handler the handler, default is a {@link NoOpRequestHeaders}
-   */
-  public void setRequestHeaderProvider(RequestHeaderProvider<HttpRequestBase> handler) {
-    requestHeaderProvider = Args.notNull(handler, "Request Header Handler");
-  }
-
-  public RequestMethodProvider getMethodProvider() {
-    return methodProvider;
-  }
-
-  public void setMethodProvider(RequestMethodProvider p) {
-    methodProvider = Args.notNull(p, "Method Provider");
-  }
-
-  public HttpAuthenticator getAuthenticator() {
-    return authenticator;
-  }
-
-  /**
-   * Set the authentication method to use for the HTTP request
-   *
-   * @see ApacheRequestAuthenticator
-   * @see ConfiguredUsernamePassword
-   * @see MetadataUsernamePassword
-   * @see ConfiguredAuthorizationHeader
-   * @see MetadataAuthorizationHeader
-   */
-  public void setAuthenticator(HttpAuthenticator authenticator) {
-    this.authenticator = Args.notNull(authenticator, "authenticator");
   }
 
   protected HttpMethod getMethod(AdaptrisMessage msg) {
@@ -285,10 +275,6 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
     return ObjectUtils.defaultIfNull(getAuthenticator(), new NoAuthentication());
   }
 
-  protected HttpClientBuilderConfigurator clientConfig() {
-    return getClientConfig();
-  }
-
   @Override
   protected void doProduce(AdaptrisMessage msg, String endpoint) throws ProduceException {
     doRequest(msg, endpoint, defaultTimeout());
@@ -299,19 +285,6 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
     logWarningIfNotNull(destWarning, () -> destWarning = true, getDestination(),
         "{} uses destination, use 'url' instead", LoggingHelper.friendlyName(this));
     mustHaveEither(getUrl(), getDestination());
-  }
-
-  public HttpClientBuilderConfigurator getClientConfig() {
-    return clientConfig;
-  }
-
-  /**
-   * Specify any custom {@code HttpClientBuilder} configuration.
-   *
-   * @param httpClientCustomiser a {@link HttpClientBuilderConfigurator} instance.
-   */
-  public void setClientConfig(HttpClientBuilderConfigurator httpClientCustomiser) {
-    clientConfig = httpClientCustomiser;
   }
 
   @Override

--- a/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.apache;
 
+import static com.adaptris.core.http.apache.ResponseHandlerFactory.OBJ_METADATA_PAYLOAD_MODIFIED;
 import static com.adaptris.core.util.DestinationHelper.logWarningIfNotNull;
 import static com.adaptris.core.util.DestinationHelper.mustHaveEither;
 import javax.validation.Valid;
@@ -40,6 +41,7 @@ import com.adaptris.core.http.client.RequestMethodProvider.RequestMethod;
 import com.adaptris.core.http.client.ResponseHeaderHandler;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.core.util.MessageHelper;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -51,6 +53,7 @@ import lombok.Setter;
  *
  */
 public abstract class HttpProducer extends RequestReplyProducerImp {
+
 
   protected static final long DEFAULT_TIMEOUT = -1;
   /**
@@ -297,4 +300,17 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
     return (T) this;
   }
 
+  /**
+   * Ensures that if the reply hasn't got a new payload then we copy the request payload into the
+   * response.
+   *
+   */
+  protected void preserveRequestPayload(AdaptrisMessage request, AdaptrisMessage response)
+      throws Exception {
+    boolean responseModifiedPayload =
+        ((Boolean) response.getObjectHeaders().get(OBJ_METADATA_PAYLOAD_MODIFIED)).booleanValue();
+    if (!responseModifiedPayload) {
+      MessageHelper.copyPayload(request, response);
+    }
+  }
 }

--- a/src/main/java/com/adaptris/core/http/apache/MetadataAuthorizationHeader.java
+++ b/src/main/java/com/adaptris/core/http/apache/MetadataAuthorizationHeader.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2015 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@ package com.adaptris.core.http.apache;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.http.HttpConstants;
@@ -27,18 +28,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Build an {@link HttpConstants#AUTHORIZATION} header from metadata.
- * 
+ *
  * @config apache-http-metadata-authorization-header
- * 
+ * @deprecated since 3.11.0 - use 'apache-http-configured-authorization-header' instead with an
+ *             expression
  */
 @XStreamAlias("apache-http-metadata-authorization-header")
+@Deprecated
+@Removal(version = "4.0.0",
+    message = "Use 'apache-http-configured-authorization-header' instead with an expression")
 public class MetadataAuthorizationHeader implements ApacheRequestAuthenticator {
 
   @NotBlank
   private String metadataKey;
-  
+
   private transient String headerValue;
-  
+
   public MetadataAuthorizationHeader() {
 
   }

--- a/src/main/java/com/adaptris/core/http/apache/MetadataResponseHandlerFactory.java
+++ b/src/main/java/com/adaptris/core/http/apache/MetadataResponseHandlerFactory.java
@@ -1,43 +1,39 @@
 package com.adaptris.core.http.apache;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-
+import java.nio.charset.Charset;
+import javax.validation.constraints.NotBlank;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
-import org.hibernate.validator.constraints.NotBlank;
-
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreConstants;
-import com.adaptris.core.MetadataElement;
-import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implementation {@link ResponseHandlerFactory} that writes the response to the named metadata key.
- * 
+ *
  * @config apache-http-metadata-response-handler
  *
  */
 @XStreamAlias("apache-http-metadata-response-handler")
+@Slf4j
+@NoArgsConstructor
 public class MetadataResponseHandlerFactory extends ResponseHandlerFactoryImpl {
 
   @NotBlank
+  @Getter
+  @Setter
   private String metadataKey;
-
-
-  public MetadataResponseHandlerFactory() {
-    super();
-  }
 
   public MetadataResponseHandlerFactory(String key) {
     this();
@@ -49,57 +45,26 @@ public class MetadataResponseHandlerFactory extends ResponseHandlerFactoryImpl {
     return new HttpResponseHandler(owner);
   }
 
-  public String getMetadataKey() {
-    return metadataKey;
-  }
-
-  public void setMetadataKey(String key) {
-    this.metadataKey = Args.notBlank(key, "Metadata Key");
-  }
-
-
-  private class HttpResponseHandler implements ResponseHandler<AdaptrisMessage> {
-
-    private HttpProducer owner;
-
-    private HttpResponseHandler(HttpProducer p) {
-      owner = p;
-    }
-
-    @Override
-    public AdaptrisMessage handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
-      int status = response.getStatusLine().getStatusCode();
-      AdaptrisMessage reply = defaultIfNull(owner.getMessageFactory()).newMessage();
-      HttpEntity entity = response.getEntity();
-      if (status > 299) {
-        if (!owner.ignoreServerResponseCode()) {
-          logAndThrow(status, entity);
-        }
-      }
-      if (entity != null) {
-        log.trace("Processing data from response {}", response.getEntity().getClass().getSimpleName());
-        String encoding = contentEncoding(entity);
-        StringBuilder builder = new StringBuilder();
-        try (Reader in = getReader(entity.getContent(), encoding);
-            StringBuilderWriter out = new StringBuilderWriter(builder)) {
-          IOUtils.copy(in, out);
-        }
-        reply.addMessageHeader(getMetadataKey(), builder.toString());
-      }
-      reply = owner.getResponseHeaderHandler().handle(response, reply);
-      reply.addMetadata(new MetadataElement(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, String.valueOf(status)));
-      reply.addObjectHeader(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, Integer.valueOf(status));
-      return reply;
+  private class HttpResponseHandler extends ResponseHandlerImpl {
+    private HttpResponseHandler(HttpProducer owner) {
+      super(owner);
     }
 
     private InputStreamReader getReader(InputStream in, String encoding) throws UnsupportedEncodingException {
-      InputStreamReader reader = null;
-      if (encoding == null) {
-        reader = new InputStreamReader(in);
-      } else {
-        reader = new InputStreamReader(in, encoding);
+      String encodingToUse = StringUtils.defaultIfEmpty(encoding, Charset.defaultCharset().name());
+      return new InputStreamReader(in, encodingToUse);
+    }
+
+    @Override
+    protected void processEntity(HttpEntity entity, String encoding, AdaptrisMessage msg)
+        throws IOException {
+      log.trace("Processing data from response {}", entity.getClass().getSimpleName());
+      StringBuilder builder = new StringBuilder();
+      try (Reader in = getReader(entity.getContent(), encoding);
+          StringBuilderWriter out = new StringBuilderWriter(builder)) {
+        IOUtils.copy(in, out);
       }
-      return reader;
+      msg.addMessageHeader(getMetadataKey(), builder.toString());
     }
 
   }

--- a/src/main/java/com/adaptris/core/http/apache/PayloadResponseHandlerFactory.java
+++ b/src/main/java/com/adaptris/core/http/apache/PayloadResponseHandlerFactory.java
@@ -1,71 +1,49 @@
 package com.adaptris.core.http.apache;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
-
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.CoreConstants;
-import com.adaptris.core.MetadataElement;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implementation {@link ResponseHandlerFactory} that writes the response to the {@link AdaptrisMessage} payload.
- * 
+ *
  * @config apache-http-payload-response-handler
  *
  */
 @XStreamAlias("apache-http-payload-response-handler")
+@Slf4j
+@NoArgsConstructor
 public class PayloadResponseHandlerFactory extends ResponseHandlerFactoryImpl {
 
-  public PayloadResponseHandlerFactory() {
-    super();
-  }
 
   @Override
   public ResponseHandler<AdaptrisMessage> createResponseHandler(HttpProducer owner) {
     return new HttpResponseHandler(owner);
   }
 
-  private class HttpResponseHandler implements ResponseHandler<AdaptrisMessage> {
-
-    private HttpProducer owner;
-
-    private HttpResponseHandler(HttpProducer p) {
-      owner = p;
+  private class HttpResponseHandler extends ResponseHandlerImpl {
+    private HttpResponseHandler(HttpProducer owner) {
+      super(owner);
     }
 
     @Override
-    public AdaptrisMessage handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
-      int status = response.getStatusLine().getStatusCode();
-      AdaptrisMessage reply = defaultIfNull(owner.getMessageFactory()).newMessage();
-      HttpEntity entity = response.getEntity();
-      if (status > 299) {
-        if (!owner.ignoreServerResponseCode()) {
-          logAndThrow(status, entity);
-        }
+    protected void processEntity(HttpEntity entity, String encoding, AdaptrisMessage msg)
+        throws IOException {
+      log.trace("Processing data from response {}", entity.getClass().getSimpleName());
+      try (InputStream in = entity.getContent();
+          OutputStream out = new BufferedOutputStream(msg.getOutputStream())) {
+        IOUtils.copy(in, out);
+        msg.setContentEncoding(encoding);
       }
-      if (entity != null) {
-        log.trace("Processing data from response {}", response.getEntity().getClass().getSimpleName());
-        String encoding = contentEncoding(entity);
-        try (InputStream in = entity.getContent(); OutputStream out = new BufferedOutputStream(reply.getOutputStream())) {
-          IOUtils.copy(in, out);
-          reply.setContentEncoding(encoding);
-        }
-      }
-      reply = owner.getResponseHeaderHandler().handle(response, reply);
-      reply.addMetadata(new MetadataElement(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, String.valueOf(status)));
-      reply.addObjectHeader(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, Integer.valueOf(status));
-      return reply;
+      msg.addObjectHeader(OBJ_METADATA_PAYLOAD_MODIFIED, Boolean.TRUE);
     }
 
   }

--- a/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactory.java
+++ b/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactory.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.http.apache;
 
 import org.apache.http.client.ResponseHandler;
-
 import com.adaptris.core.AdaptrisMessage;
 
 /**
@@ -10,6 +9,13 @@ import com.adaptris.core.AdaptrisMessage;
  *
  */
 public interface ResponseHandlerFactory {
+
+  /**
+   * Key in object metadata that tells us if the payload has been modified by the ResponseHandler.
+   */
+  public static final String OBJ_METADATA_PAYLOAD_MODIFIED =
+      ResponseHandler.class.getSimpleName() + "_modifiedPayload";
+
 
   ResponseHandler<AdaptrisMessage> createResponseHandler(HttpProducer owner);
 

--- a/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactoryImpl.java
+++ b/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactoryImpl.java
@@ -1,49 +1,91 @@
 package com.adaptris.core.http.apache;
 
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-
+import java.nio.charset.Charset;
+import java.util.Optional;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.entity.ContentType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreConstants;
+import com.adaptris.core.MetadataElement;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-import com.adaptris.util.stream.Slf4jLoggingOutputStream;
 
+@NoArgsConstructor
+@Slf4j
 public abstract class ResponseHandlerFactoryImpl implements ResponseHandlerFactory {
 
-  protected transient Logger log = LoggerFactory.getLogger(this.getClass());
 
-  public ResponseHandlerFactoryImpl() {
+  protected abstract class ResponseHandlerImpl implements ResponseHandler<AdaptrisMessage> {
 
-  }
+    protected HttpProducer owner;
 
-  protected void logAndThrow(int status, HttpEntity entity) throws IOException {
-    if (entity != null) {
-      if (log.isTraceEnabled()) {
-        String encoding = contentEncoding(entity);
-        try (InputStream in = entity.getContent();
-            OutputStream slf4j = new Slf4jLoggingOutputStream(log, Slf4jLoggingOutputStream.LogLevel.TRACE);
-            PrintStream out = encoding == null ? new PrintStream(slf4j) : new PrintStream(slf4j, false, encoding)) {
-          out.println("Error Data from remote server :");
-          IOUtils.copy(in, out);
+    protected ResponseHandlerImpl(HttpProducer owner) {
+      this.owner = owner;
+    }
+
+    // Abuse Generated annotation for covarge purposes since this isn't interesting in the context
+    // of things.
+    @lombok.Generated
+    protected void logAndThrow(int status, HttpEntity entity) throws IOException {
+      if (entity != null) {
+        if (log.isTraceEnabled()) {
+          String charset = StringUtils.defaultIfEmpty(contentEncoding(entity), Charset.defaultCharset().name());
+          try (InputStream in = entity.getContent()) {
+            log.trace("Error Data from remote server : {}", IOUtils.toString(in, charset));
+         } catch (IOException e) {
+            log.trace("No Error Data available");
+          }
         }
-        catch (IOException e) {
-          log.trace("No Error Data available");
+      }
+      throw new IOException("Failed to complete operation, got " + status);
+    }
+
+    // Since logAndThrow will always throw an exception, there are branches that are
+    // not covered according to coverage reports.
+    protected void exceptionBreakout(int status, HttpEntity entity) throws IOException {
+      if (status > 299) {
+        if (!owner.ignoreServerResponseCode()) {
+          logAndThrow(status, entity);
         }
       }
     }
-    throw new IOException("Failed to complete operation, got " + status);
+
+    protected String contentEncoding(HttpEntity entity) {
+      ContentType contentType =
+          Optional.ofNullable(ContentType.get(entity)).orElse(ContentType.create("text/plain"));
+      return Optional.ofNullable(contentType.getCharset()).map((cs) -> cs.name()).orElse(null);
+    }
+
+    @Override
+    public AdaptrisMessage handleResponse(HttpResponse response)
+        throws ClientProtocolException, IOException {
+      int status = response.getStatusLine().getStatusCode();
+      AdaptrisMessage reply = defaultIfNull(owner.getMessageFactory()).newMessage();
+      reply.addObjectHeader(OBJ_METADATA_PAYLOAD_MODIFIED, Boolean.FALSE);
+      HttpEntity entity = response.getEntity();
+      exceptionBreakout(status, entity);
+      if (entity != null) {
+        processEntity(entity, contentEncoding(entity), reply);
+      }
+      reply = owner.getResponseHeaderHandler().handle(response, reply);
+      reply.addMetadata(
+          new MetadataElement(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, String.valueOf(status)));
+      reply.addObjectHeader(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE, Integer.valueOf(status));
+      return reply;
+    }
+
+    protected abstract void processEntity(HttpEntity entity, String encoding, AdaptrisMessage msg)
+        throws IOException;
+
   }
 
-  protected String contentEncoding(HttpEntity entity) {
-    ContentType contentType = ContentType.get(entity);
-    if (contentType == null) {
-      contentType = ContentType.create("text/plain");
-    }
-    return contentType.getCharset() != null ? contentType.getCharset().name() : null;
-  }
 }

--- a/src/test/java/com/adaptris/core/http/apache/AdaptrisMessageEntityTest.java
+++ b/src/test/java/com/adaptris/core/http/apache/AdaptrisMessageEntityTest.java
@@ -1,0 +1,62 @@
+package com.adaptris.core.http.apache;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.http.ConfiguredContentTypeProvider;
+
+public class AdaptrisMessageEntityTest {
+
+  private static final byte[] PAYLOAD = "Hello World".getBytes(Charset.defaultCharset());
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @After
+  public void tearDown() throws Exception {}
+
+  @Test
+  public void testGetters() throws Exception {
+    ConfiguredContentTypeProvider ct = new ConfiguredContentTypeProvider("text/plain");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
+    AdaptrisMessageEntity entity = new AdaptrisMessageEntity(msg, ct);
+    assertTrue(entity.isRepeatable());
+    assertTrue(entity.isStreaming());
+    assertTrue(entity.getContentLength() > 0);
+    assertNotNull(entity.getContentType());
+  }
+
+
+  @Test
+  public void testGetContent() throws Exception {
+    ConfiguredContentTypeProvider ct = new ConfiguredContentTypeProvider("text/plain");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
+    AdaptrisMessageEntity entity = new AdaptrisMessageEntity(msg, ct);
+    try (InputStream in = entity.getContent();
+        ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      IOUtils.copy(in, out);
+      assertArrayEquals(PAYLOAD, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testWriteTo() throws Exception {
+    ConfiguredContentTypeProvider ct = new ConfiguredContentTypeProvider("text/plain");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PAYLOAD);
+    AdaptrisMessageEntity entity = new AdaptrisMessageEntity(msg, ct);
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      entity.writeTo(out);
+      assertArrayEquals(PAYLOAD, out.toByteArray());
+    }
+  }
+
+}

--- a/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -103,7 +103,7 @@ public class ApacheHttpProducerTest extends ProducerCase {
     try {
       p.setRequestHeaderProvider(null);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (Exception expected) {
 
     }
     assertEquals(NoOpRequestHeaders.class, p.getRequestHeaderProvider().getClass());
@@ -119,7 +119,7 @@ public class ApacheHttpProducerTest extends ProducerCase {
     try {
       p.setResponseHeaderHandler(null);
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (Exception expected) {
 
     }
     assertEquals(DiscardResponseHeaders.class, p.getResponseHeaderHandler().getClass());
@@ -541,7 +541,7 @@ public class ApacheHttpProducerTest extends ProducerCase {
 
   // INTERLOK-2682
   @Test
-  public void test_ReplyMetadataReplacesOriginal() throws Exception {
+  public void test_ReplyMetadata_ShouldNotOverwrite() throws Exception {
     MockMessageProducer mock = new MockMessageProducer();
     HttpConnection jc = createConnection();
     JettyMessageConsumer mc = createConsumer(URL_TO_POST_TO);

--- a/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -63,9 +63,10 @@ import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.adaptris.core.services.WaitService;
 import com.adaptris.core.services.metadata.AddMetadataService;
-import com.adaptris.core.services.metadata.PayloadFromMetadataService;
+import com.adaptris.core.services.metadata.PayloadFromTemplateService;
 import com.adaptris.core.stubs.MockMessageProducer;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.util.GuidGeneratorWithTime;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.util.text.Conversion;
@@ -580,7 +581,7 @@ public class ApacheHttpProducerTest extends ProducerCase {
     JettyMessageConsumer mc = createConsumer(URL_TO_POST_TO);
     mc.setSendProcessingInterval(new TimeInterval(100L, TimeUnit.MILLISECONDS));
     ServiceList services = new ServiceList();
-    services.add(new PayloadFromMetadataService(TEXT));
+    services.add(new PayloadFromTemplateService().withTemplate(TEXT));
     services.add(new WaitService(new TimeInterval(2L, TimeUnit.SECONDS)));
     services.add(new StandaloneProducer(new StandardResponseProducer(HttpStatus.OK_200)));
 
@@ -603,6 +604,39 @@ public class ApacheHttpProducerTest extends ProducerCase {
       Thread.currentThread().setName(threadName);
     }
   }
+
+
+  // This is INTERLOK-3396 effectively. Send data, but put the reply into metadata.
+  @Test
+  public void testRequest_ReplyIntoMetadata() throws Exception {
+    MockMessageProducer mock = new MockMessageProducer();
+    String responseText = new GuidGeneratorWithTime().create(this);
+    HttpConnection jc = createConnection();
+    JettyMessageConsumer mc = createConsumer(URL_TO_POST_TO);
+
+    ServiceList services = new ServiceList();
+    services.add(new PayloadFromTemplateService().withTemplate(responseText));
+    services.add(new JettyResponseService(HttpStatus.OK_200.getStatusCode(), "text/plain"));
+    Channel c = createChannel(jc, createWorkflow(mc, mock, services));
+
+    ApacheHttpProducer http = new ApacheHttpProducer().withURL(createURL(c));
+    http.setMethodProvider(new ConfiguredRequestMethodProvider(RequestMethod.POST));
+    http.setResponseHandlerFactory(new MetadataResponseHandlerFactory("httpReplyPayload"));
+
+    StandaloneRequestor producer = new StandaloneRequestor(http);
+    AdaptrisMessage msg = new DefaultMessageFactory().newMessage(TEXT);
+    try {
+      start(c);
+      ServiceCase.execute(producer, msg);
+      waitForMessages(mock, 1);
+    } finally {
+      stopAndRelease(c);
+    }
+    assertTrue(msg.containsKey("httpReplyPayload"));
+    assertEquals(responseText, msg.getMetadataValue("httpReplyPayload"));
+    assertEquals(TEXT, msg.getContent());
+  }
+
 
   @Override
   protected Object retrieveObjectForSampleConfig() {


### PR DESCRIPTION
## Motivation

If you configure an `apache-http-producer` with a response-handler that writes to metadata rather than the payload.

```
<standalone-requestor>
  <producer class="apache-http-producer">
     ...
     <response-handler-factory class="apache-http-metadata-response-handler">
       <metadata-key>MyMetadataKey</metadata-key>
     </response-handler-factory>
  </producer>
</standalone-requestor>
```

Then the payload is rendered as empty, after the service is executed; which is basically wrong

## Modification

- Write a test that explicitly tests for that behaviour; it fails...
- Add a marker that tells the caller whether or not the ResponseHandler modified the payload (via object metadata)
- This marker is then used by the producer to preserve the original payload if the reply does not have a payload.
- Refactor the response handlers for testability to have less duplication of code.
- Original test that illuminated the bug now passes (yay).

## Result

The payload should no longer be blank post execution

## Testing

* Set the payload as something e.g. __Hello World__
* Configure a standalone requestor as above against any external resource; and store the result as metadata.
* The payload should still be __Hello World__

