### PR TITLE
updated the ConfigDeprecated/Removal annotations; from 3.12 to 4

### DIFF
--- a/src/main/java/com/adaptris/core/http/apache/CustomApacheHttpProducer.java
+++ b/src/main/java/com/adaptris/core/http/apache/CustomApacheHttpProducer.java
@@ -36,7 +36,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
     "privateKeyPassword", "truststore", "hostnameVerification", "tlsVersions", "cipherSuites", "clientConfig"
 })
 @Deprecated
-@ConfigDeprecated(removalVersion = "3.12.0", groups = Deprecated.class)
+@ConfigDeprecated(removalVersion = "4.0.0", groups = Deprecated.class)
 public class CustomApacheHttpProducer extends ApacheHttpProducer {
 
   @AdvancedConfig


### PR DESCRIPTION
## Motivation

Config components are marked as being removed in 3.12.0 but these changes are now being delayed until 4.0.0

## Modification

updated the ConfigDeprecated/Removal annotations

## Result

any warnings generated from config checker / ui will be correct

## Testing

just eyeball the changes and make sure nothing stupid was done
