### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,8 +310,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "HTTP(s) using Apache http client")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-http-client")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/cookbook-http-client.html")
         properties.appendNode("target", "3.8.0+")
         properties.appendNode("tags", "http,https")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
