### PR TITLE
features - INTERLOK-3845 & INTERLOK-3847 - request timeout & potential resource leaks

### DIFF
--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ApacheHttpProducer.java
@@ -1,17 +1,5 @@
 package com.adaptris.core.http.apache;
 
-import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import javax.validation.Valid;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -28,6 +16,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+import javax.validation.Valid;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 
 /**
  * Producer implementation that uses the Apache HTTP Client as the underlying transport.

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DefaultClientBuilder.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DefaultClientBuilder.java
@@ -90,12 +90,15 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
     RequestConfig.Builder requestCfg = RequestConfig.custom();
     if (getConnectTimeout() != null) {
       requestCfg.setConnectTimeout(Long.valueOf(getConnectTimeout().toMilliseconds()).intValue());
+      requestCfg.setConnectionRequestTimeout(Long.valueOf(getConnectTimeout().toMilliseconds()).intValue());
+    } else if (timeout >= 0) {
+      requestCfg.setConnectTimeout(Long.valueOf(timeout).intValue());
+      requestCfg.setConnectionRequestTimeout(Long.valueOf(timeout).intValue());
     }
     if (getReadTimeout() != null) {
       requestCfg.setSocketTimeout(Long.valueOf(getReadTimeout().toMilliseconds()).intValue());
-    }
-    if (timeout != HttpProducer.DEFAULT_TIMEOUT) {
-      requestCfg.setConnectionRequestTimeout(Long.valueOf(timeout).intValue());
+      builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(Long.valueOf(getReadTimeout().toMilliseconds()).intValue()).build());
+    } else if (timeout >= 0) {
       requestCfg.setSocketTimeout(Long.valueOf(timeout).intValue());
       builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(Long.valueOf(timeout).intValue()).build());
     }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DefaultClientBuilder.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DefaultClientBuilder.java
@@ -95,6 +95,7 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
       requestCfg.setSocketTimeout(Long.valueOf(getReadTimeout().toMilliseconds()).intValue());
     }
     if (timeout != HttpProducer.DEFAULT_TIMEOUT) {
+      requestCfg.setConnectionRequestTimeout(Long.valueOf(timeout).intValue());
       requestCfg.setSocketTimeout(Long.valueOf(timeout).intValue());
       builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(Long.valueOf(timeout).intValue()).build());
     }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -1,21 +1,5 @@
 package com.adaptris.core.http.apache;
 
-import static com.adaptris.core.http.apache.ResponseHandlerFactory.OBJ_METADATA_PAYLOAD_MODIFIED;
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
@@ -42,6 +26,24 @@ import com.adaptris.interlok.util.Args;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpTrace;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import static com.adaptris.core.http.apache.ResponseHandlerFactory.OBJ_METADATA_PAYLOAD_MODIFIED;
 
 /**
  * Abstract base class for all Apache HTTP producer classes.

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpProducer.java
@@ -51,8 +51,8 @@ import lombok.Setter;
  */
 public abstract class HttpProducer extends RequestReplyProducerImp {
 
-
   protected static final long DEFAULT_TIMEOUT = -1;
+
   /**
    * Maps various methods supported by the Apache Http client.
    *
@@ -228,8 +228,6 @@ public abstract class HttpProducer extends RequestReplyProducerImp {
   @Setter
   @NotBlank
   private String url;
-
-  private transient boolean destWarning;
 
   public HttpProducer() {
     super();

--- a/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -73,9 +73,6 @@ import com.adaptris.util.text.Conversion;
 @SuppressWarnings("deprecation")
 public class ApacheHttpProducerTest extends ExampleProducerCase {
 
-  protected static Logger log = LoggerFactory.getLogger(ApacheHttpProducerTest.class);
-
-
   @Test
   public void testSetIgnoreServerResponse() throws Exception {
     ApacheHttpProducer p = new ApacheHttpProducer();

--- a/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -1,26 +1,5 @@
 package com.adaptris.core.http.apache;
 
-import static com.adaptris.core.http.apache.JettyHelper.JETTY_USER_REALM;
-import static com.adaptris.core.http.apache.JettyHelper.METADATA_KEY_CONTENT_TYPE;
-import static com.adaptris.core.http.apache.JettyHelper.TEXT;
-import static com.adaptris.core.http.apache.JettyHelper.URL_TO_POST_TO;
-import static com.adaptris.core.http.apache.JettyHelper.createAndStartChannel;
-import static com.adaptris.core.http.apache.JettyHelper.createChannel;
-import static com.adaptris.core.http.apache.JettyHelper.createConnection;
-import static com.adaptris.core.http.apache.JettyHelper.createConsumer;
-import static com.adaptris.core.http.apache.JettyHelper.createURL;
-import static com.adaptris.core.http.apache.JettyHelper.createWorkflow;
-import static com.adaptris.core.http.apache.JettyHelper.stopAndRelease;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Channel;
@@ -69,6 +48,27 @@ import com.adaptris.util.GuidGeneratorWithTime;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.util.text.Conversion;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static com.adaptris.core.http.apache.JettyHelper.JETTY_USER_REALM;
+import static com.adaptris.core.http.apache.JettyHelper.METADATA_KEY_CONTENT_TYPE;
+import static com.adaptris.core.http.apache.JettyHelper.TEXT;
+import static com.adaptris.core.http.apache.JettyHelper.URL_TO_POST_TO;
+import static com.adaptris.core.http.apache.JettyHelper.createAndStartChannel;
+import static com.adaptris.core.http.apache.JettyHelper.createChannel;
+import static com.adaptris.core.http.apache.JettyHelper.createConnection;
+import static com.adaptris.core.http.apache.JettyHelper.createConsumer;
+import static com.adaptris.core.http.apache.JettyHelper.createURL;
+import static com.adaptris.core.http.apache.JettyHelper.createWorkflow;
+import static com.adaptris.core.http.apache.JettyHelper.stopAndRelease;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class ApacheHttpProducerTest extends ExampleProducerCase {

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -108,22 +108,14 @@ public class ApacheHttpProducer extends HttpProducer {
 
   private synchronized CloseableHttpClient getClient(HttpUriRequestBase httpOperation, HttpClientBuilderConfigurator clientConfig, long timeout) throws Exception
   {
-    if (httpClient == null)
+    if (httpClient == null || clientConfig != null)
     {
+      /*
+       * Either create an HTTP client instance or reconfigure with clientConfig.
+       */
       httpClient = HttpClientBuilderConfigurator.defaultIfNull(clientConfig).configure(HttpClients.custom(), timeout).build();
     }
-    // update timeouts if necessary
-    if (clientConfig != null && clientConfig instanceof DefaultClientBuilder)
-    {
-      DefaultClientBuilder clientBuilder = (DefaultClientBuilder)clientConfig;
-      RequestConfig requestConfig = httpOperation.getConfig();
-      RequestConfig.Builder builder = requestConfig != null ? RequestConfig.copy(requestConfig) : RequestConfig.custom();
-      builder.setConnectionRequestTimeout(Timeout.ofMilliseconds(clientBuilder.getConnectTimeout().toMilliseconds()));
-      builder.setConnectTimeout(Timeout.ofMilliseconds(clientBuilder.getConnectTimeout().toMilliseconds()));
-      builder.setResponseTimeout(Timeout.ofMilliseconds(clientBuilder.getReadTimeout().toMilliseconds()));
-      httpOperation.setConfig(builder.build());
-    }
-    else if (timeout > 0)
+    if (clientConfig == null && timeout > 0)
     {
       RequestConfig requestConfig = httpOperation.getConfig();
       RequestConfig.Builder builder = requestConfig != null ? RequestConfig.copy(requestConfig) : RequestConfig.custom();

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -74,7 +74,7 @@ public class ApacheHttpProducer extends HttpProducer {
    * to execute multiple requests concurrently taking full advantage of
    * persistent connection re-use and connection pooling.
    */
-  private static transient CloseableHttpClient httpClient;
+  private transient CloseableHttpClient httpClient;
 
   protected ResponseHandlerFactory responseHandlerFactory() {
     return ObjectUtils.defaultIfNull(getResponseHandlerFactory(), DEFAULT_HANDLER);

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -11,7 +11,6 @@ import com.adaptris.core.http.ResourceAuthenticator.ResourceTarget;
 import com.adaptris.core.http.auth.HttpAuthenticator;
 import com.adaptris.core.http.auth.ResourceTargetMatcher;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.interlok.util.Closer;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +21,6 @@ import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.util.Timeout;
 

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -22,6 +22,7 @@ import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.io.Closer;
 import org.apache.hc.core5.util.Timeout;
 
 import javax.validation.Valid;
@@ -75,6 +76,13 @@ public class ApacheHttpProducer extends HttpProducer {
    * persistent connection re-use and connection pooling.
    */
   private transient CloseableHttpClient httpClient;
+
+  @Override
+  public synchronized void close() {
+    Closer.closeQuietly(httpClient);
+    httpClient = null;
+    super.close();
+  }
 
   protected ResponseHandlerFactory responseHandlerFactory() {
     return ObjectUtils.defaultIfNull(getResponseHandlerFactory(), DEFAULT_HANDLER);

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -76,7 +76,6 @@ public class ApacheHttpProducer extends HttpProducer {
    * persistent connection re-use and connection pooling.
    */
   private static transient CloseableHttpClient httpClient;
-  private static transient HttpClientBuilderConfigurator httpConfig;
 
   protected ResponseHandlerFactory responseHandlerFactory() {
     return ObjectUtils.defaultIfNull(getResponseHandlerFactory(), DEFAULT_HANDLER);
@@ -130,7 +129,6 @@ public class ApacheHttpProducer extends HttpProducer {
     }
     return httpClient;
   }
-
 
   protected class ApacheResourceTargetMatcher implements ResourceTargetMatcher {
 
@@ -191,6 +189,4 @@ public class ApacheHttpProducer extends HttpProducer {
       return rc;
     }
   }
-
-
 }

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -95,7 +95,7 @@ public class ApacheHttpProducer extends HttpProducer {
       HttpUriRequestBase httpOperation = getMethod(msg).create(uri);
       auth.setup(uri, msg, new ApacheResourceTargetMatcher(httpOperation.getUri()));
       log.trace("Attempting [{}] against [{}]", httpOperation.getMethod(), httpOperation.getUri());
-      HttpClient httpClient = createClient(httpOperation, getClientConfig(), timeout);
+      HttpClient httpClient = getClient(httpOperation, getClientConfig(), timeout);
       if (auth instanceof ApacheRequestAuthenticator)
       {
         ((ApacheRequestAuthenticator) auth).configure(httpOperation);
@@ -112,7 +112,7 @@ public class ApacheHttpProducer extends HttpProducer {
     }
   }
 
-  private static synchronized CloseableHttpClient createClient(HttpUriRequestBase httpOperation, HttpClientBuilderConfigurator clientConfig, long timeout) throws Exception
+  private static synchronized CloseableHttpClient getClient(HttpUriRequestBase httpOperation, HttpClientBuilderConfigurator clientConfig, long timeout) throws Exception
   {
     if (httpClient == null)
     {
@@ -125,7 +125,7 @@ public class ApacheHttpProducer extends HttpProducer {
       builder.setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout));
       builder.setConnectTimeout(Timeout.ofMilliseconds(timeout));
       builder.setResponseTimeout(Timeout.ofMilliseconds(timeout));
-      httpOperation.setConfig(requestConfig);
+      httpOperation.setConfig(builder.build());
     }
     return httpClient;
   }

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/ApacheHttpProducer.java
@@ -83,6 +83,7 @@ public class ApacheHttpProducer extends HttpProducer {
 
   @Override
   public synchronized void close() {
+    log.trace("Closing HTTP client");
     Closer.closeQuietly(httpClient);
     httpClient = null;
     super.close();
@@ -116,10 +117,12 @@ public class ApacheHttpProducer extends HttpProducer {
   {
     if (httpClient == null)
     {
+      // create client instance
       httpClient = HttpClientBuilderConfigurator.defaultIfNull(clientConfig).configure(HttpClients.custom(), timeout).build();
     }
     else if (timeout > 0)
     {
+      // reset non-default timeout on existing client instance
       RequestConfig requestConfig = httpOperation.getConfig();
       RequestConfig.Builder builder = requestConfig != null ? RequestConfig.copy(requestConfig) : RequestConfig.custom();
       builder.setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout));

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
@@ -28,7 +28,10 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
 
 import javax.validation.Valid;
@@ -89,6 +92,7 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
    * @return the builder.
    */
   protected HttpClientBuilder customiseTimeouts(HttpClientBuilder builder, long timeout) {
+    BasicHttpClientConnectionManager connectionManager = new BasicHttpClientConnectionManager();
     RequestConfig.Builder requestCfg = RequestConfig.custom();
     if (getConnectTimeout() != null) {
       requestCfg.setConnectTimeout(Timeout.ofMilliseconds(getConnectTimeout().toMilliseconds()));
@@ -99,10 +103,13 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
     }
     if (getReadTimeout() != null) {
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(getReadTimeout().toMilliseconds()));
+      connectionManager.setSocketConfig(SocketConfig.custom().setSoTimeout(Timeout.ofMilliseconds(getReadTimeout().toMilliseconds())).build());
     } else if (timeout >= 0) {
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(timeout));
+      connectionManager.setSocketConfig(SocketConfig.custom().setSoTimeout(Timeout.ofMilliseconds(timeout)).build());
     }
     builder.setDefaultRequestConfig(requestCfg.build());
+    builder.setConnectionManager(connectionManager);
     return builder;
   }
 

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
@@ -92,12 +92,14 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
     RequestConfig.Builder requestCfg = RequestConfig.custom();
     if (getConnectTimeout() != null) {
       requestCfg.setConnectTimeout(Timeout.ofMilliseconds(getConnectTimeout().toMilliseconds()));
+      requestCfg.setConnectionRequestTimeout(Timeout.ofMilliseconds(getConnectTimeout().toMilliseconds()));
+    } else if (timeout >= 0) {
+      requestCfg.setConnectTimeout(Timeout.ofMilliseconds(timeout));
+      requestCfg.setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout));
     }
     if (getReadTimeout() != null) {
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(getReadTimeout().toMilliseconds()));
-    }
-    if (timeout != HttpProducer.DEFAULT_TIMEOUT) {
-      requestCfg.setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout));
+    } else if (timeout >= 0) {
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(timeout));
     }
     builder.setDefaultRequestConfig(requestCfg.build());

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/DefaultClientBuilder.java
@@ -97,8 +97,8 @@ public class DefaultClientBuilder implements HttpClientBuilderConfigurator {
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(getReadTimeout().toMilliseconds()));
     }
     if (timeout != HttpProducer.DEFAULT_TIMEOUT) {
+      requestCfg.setConnectionRequestTimeout(Timeout.ofMilliseconds(timeout));
       requestCfg.setResponseTimeout(Timeout.ofMilliseconds(timeout));
-      //builder.setDefaultRequestConfig(SocketConfig.custom().setSoTimeout(Timeout.ofMilliseconds(timeout)).build());
     }
     builder.setDefaultRequestConfig(requestCfg.build());
     return builder;

--- a/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/HttpProducer.java
+++ b/interlok-apache-http5/src/main/java/com/adaptris/core/http/apache5/HttpProducer.java
@@ -53,8 +53,8 @@ import static com.adaptris.core.http.apache5.ResponseHandlerFactory.OBJ_METADATA
  */
 public abstract class HttpProducer extends RequestReplyProducerImp {
 
-
   protected static final long DEFAULT_TIMEOUT = -1;
+
   /**
    * Maps various methods supported by the Apache Http client.
    *

--- a/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
+++ b/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
@@ -72,9 +72,6 @@ import com.adaptris.util.text.Conversion;
 @SuppressWarnings("deprecation")
 public class ApacheHttpProducerTest extends ExampleProducerCase {
 
-  protected static Logger log = LoggerFactory.getLogger(ApacheHttpProducerTest.class);
-
-
   @Test
   public void testSetIgnoreServerResponse() throws Exception {
     ApacheHttpProducer p = new ApacheHttpProducer();
@@ -708,5 +705,4 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
     handler.setLoginService(login);
     return handler;
   }
-
 }

--- a/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
+++ b/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
@@ -1,35 +1,5 @@
 package com.adaptris.core.http.apache5;
 
-import static com.adaptris.core.http.apache5.JettyHelper.JETTY_USER_REALM;
-import static com.adaptris.core.http.apache5.JettyHelper.METADATA_KEY_CONTENT_TYPE;
-import static com.adaptris.core.http.apache5.JettyHelper.TEXT;
-import static com.adaptris.core.http.apache5.JettyHelper.URL_TO_POST_TO;
-import static com.adaptris.core.http.apache5.JettyHelper.createAndStartChannel;
-import static com.adaptris.core.http.apache5.JettyHelper.createChannel;
-import static com.adaptris.core.http.apache5.JettyHelper.createConnection;
-import static com.adaptris.core.http.apache5.JettyHelper.createConsumer;
-import static com.adaptris.core.http.apache5.JettyHelper.createURL;
-import static com.adaptris.core.http.apache5.JettyHelper.createWorkflow;
-import static com.adaptris.core.http.apache5.JettyHelper.stopAndRelease;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-
-import com.adaptris.core.http.apache5.request.AcceptEncoding;
-import com.adaptris.core.http.apache5.request.BasicHMACSignature;
-import com.adaptris.core.http.apache5.request.DateHeader;
-import com.adaptris.core.http.apache5.request.HMACSignatureImpl;
-import com.adaptris.core.http.apache5.request.RemoveHeaders;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.Channel;
@@ -44,6 +14,11 @@ import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.http.ConfiguredContentTypeProvider;
 import com.adaptris.core.http.HttpConstants;
 import com.adaptris.core.http.RawContentTypeProvider;
+import com.adaptris.core.http.apache5.request.AcceptEncoding;
+import com.adaptris.core.http.apache5.request.BasicHMACSignature;
+import com.adaptris.core.http.apache5.request.DateHeader;
+import com.adaptris.core.http.apache5.request.HMACSignatureImpl;
+import com.adaptris.core.http.apache5.request.RemoveHeaders;
 import com.adaptris.core.http.auth.AdapterResourceAuthenticator;
 import com.adaptris.core.http.auth.ConfiguredUsernamePassword;
 import com.adaptris.core.http.auth.MetadataUsernamePassword;
@@ -71,6 +46,27 @@ import com.adaptris.util.GuidGeneratorWithTime;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.TimeInterval;
 import com.adaptris.util.text.Conversion;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static com.adaptris.core.http.apache5.JettyHelper.JETTY_USER_REALM;
+import static com.adaptris.core.http.apache5.JettyHelper.METADATA_KEY_CONTENT_TYPE;
+import static com.adaptris.core.http.apache5.JettyHelper.TEXT;
+import static com.adaptris.core.http.apache5.JettyHelper.URL_TO_POST_TO;
+import static com.adaptris.core.http.apache5.JettyHelper.createAndStartChannel;
+import static com.adaptris.core.http.apache5.JettyHelper.createChannel;
+import static com.adaptris.core.http.apache5.JettyHelper.createConnection;
+import static com.adaptris.core.http.apache5.JettyHelper.createConsumer;
+import static com.adaptris.core.http.apache5.JettyHelper.createURL;
+import static com.adaptris.core.http.apache5.JettyHelper.createWorkflow;
+import static com.adaptris.core.http.apache5.JettyHelper.stopAndRelease;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
 public class ApacheHttpProducerTest extends ExampleProducerCase {

--- a/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
+++ b/interlok-apache-http5/src/test/java/com/adaptris/core/http/apache5/ApacheHttpProducerTest.java
@@ -229,14 +229,12 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
   public void testProduce_WithInterceptors() throws Exception {
     MockMessageProducer mock = new MockMessageProducer();
     ApacheHttpProducer http = new ApacheHttpProducer();
-
-    resetHttpClient(http);
-
     // empty RequestInterceptorClientBuilder just to get an empty list for coverage
     CompositeClientBuilder builder = new CompositeClientBuilder().withBuilders(new DefaultClientBuilder(),
-        new RequestInterceptorClientBuilder().withInterceptors(new RemoveHeaders("Accept-Encoding", "User-Agent", "Connection"),
-            new AcceptEncoding("gzip", "compress", "deflate", "*"),
-            new DateHeader()),
+        new RequestInterceptorClientBuilder().withInterceptors(
+                new RemoveHeaders("Accept-Encoding", "User-Agent", "Connection"),
+                new AcceptEncoding("gzip", "compress", "deflate", "*"),
+                new DateHeader()),
         new RequestInterceptorClientBuilder());
     http.setClientConfig(builder);
     AdaptrisMessage msg = new DefaultMessageFactory().newMessage(TEXT);
@@ -254,9 +252,6 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
   public void testProduce_WithFewerInterceptors() throws Exception {
     MockMessageProducer mock = new MockMessageProducer();
     ApacheHttpProducer http = new ApacheHttpProducer();
-
-    resetHttpClient(http);
-
     // empty RequestInterceptorClientBuilder just to get an empty list for coverage
     CompositeClientBuilder builder = new CompositeClientBuilder().withBuilders(new DefaultClientBuilder(),
             new RequestInterceptorClientBuilder().withInterceptors(new AcceptEncoding()));
@@ -274,9 +269,6 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
   public void testProduce_With_HMAC() throws Exception {
     MockMessageProducer mock = new MockMessageProducer();
     ApacheHttpProducer http = new ApacheHttpProducer();
-
-    resetHttpClient(http);
-
     BasicHMACSignature hmac = new BasicHMACSignature().withIdentity("MyIdentity").withHeaders("Date")
         .withSecretKey("MySecretKey").withTargetHeader("hmac").withEncoding(HMACSignatureImpl.Encoding.BASE64)
         .withHmacAlgorithm(HMACSignatureImpl.Algorithm.HMAC_SHA256);
@@ -716,24 +708,5 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
     handler.setSecurityConstraints(Arrays.asList(securityConstraint));
     handler.setLoginService(login);
     return handler;
-  }
-
-  private static void resetHttpClient(ApacheHttpProducer producer)
-  {
-    for (Field f : ApacheHttpProducer.class.getDeclaredFields())
-    {
-      if (f.getName().equals("httpClient"))
-      {
-        try
-        {
-          f.setAccessible(true);
-          f.set(producer, null);
-        }
-        catch (IllegalAccessException e)
-        {
-          // do nothing
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
## Motivation

1. The static member `httpClient` does not need to be closed (this defeats the purpose of keeping it around to reuse).
2. Not all of the connection/request/response timeouts are being used, which is causing issues with OAuth.

## Modification

1. General tidy-up of the Apache5 `HttpProducer`
2. Set timeouts; as well as resetting them as necessary when reusing the HTTP client instance

## PR Checklist

- [x] been self-reviewed.
- [x] Update javadocs for most classes and all non-trivial methods
- [x] Update supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

When using the HTTP producer there should be no change, however, setting timeouts should result in said timeouts being adhered to.

## Testing
[Attached](https://github.com/adaptris/interlok-apache-http/files/7481884/adapter.xml.txt) is a [simple config](https://github.com/adaptris/interlok-apache-http/files/7481884/adapter.xml.txt) that makes use of the `HttpProducer` (as well as setting timeouts). It has been tested against a simple echo server and a non-responding `netcat` to verify timeouts et al.
