### PR TITLE
Add support for CredentialsProvider in apache-http

### DIFF
--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/AnyScope.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/AnyScope.java
@@ -1,0 +1,22 @@
+package interlok.http.apache.credentials;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+import org.apache.http.auth.AuthScope;
+
+/**
+ * Returns {@code org.apache.http.auth.AuthScope#ANY} when requested to build a scope.
+ *
+ * @config apache-any-authentication-scope
+ */
+@XStreamAlias("apache-any-authentication-scope")
+@ComponentProfile(summary="Any authentication scope")
+@NoArgsConstructor
+public class AnyScope implements AuthScopeBuilder {
+
+  @Override
+  public AuthScope build() {
+    return AuthScope.ANY;
+  }
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/AuthScopeBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/AuthScopeBuilder.java
@@ -1,0 +1,15 @@
+package interlok.http.apache.credentials;
+
+import org.apache.http.auth.AuthScope;
+
+/**
+ * Adds support for {@code org.apache.http.auth.AuthScope} for username and password in a configuration friendly way.
+ */
+@FunctionalInterface
+public interface AuthScopeBuilder {
+
+  /**
+   * Build the {@code AuthScope} instance.
+   */
+  AuthScope build();
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ClientBuilderWithCredentials.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ClientBuilderWithCredentials.java
@@ -1,0 +1,53 @@
+package interlok.http.apache.credentials;
+
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import interlok.http.apache.credentials.CredentialsProviderBuilder;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
+
+/**
+ * Allows you to specify a {@code CredentialsProvider} as a default for the {@code HttpClientBuilder}.
+ * <p>
+ * Most of the time you more likely to configure an {@link com.adaptris.core.http.auth.HttpAuthenticator} instance on
+ * the producer, but this is included for completeness as a way of configuring the {@link HttpClientBuilder}.
+ * </p>
+ *
+ * @config credentials-provider-apache-http-client-builder
+ */
+@XStreamAlias("credentials-provider-apache-http-client-builder")
+@ComponentProfile(since = "4.5.0", summary = "Allows you to configure a 'CredentialsProvider' when building the HttpClient")
+@NoArgsConstructor
+public class ClientBuilderWithCredentials implements HttpClientBuilderConfigurator {
+
+  /**
+   * The credentials provider.
+   * <p>If not explicitly configured, then the resulting {@code CredentialsProvider} is a {@code
+   * org.apache.http.impl.client.SystemDefaultCredentialsProvider} with no configuration.
+   * </p>
+   */
+  @Getter
+  @Setter
+  private CredentialsProviderBuilder credentialsProvider;
+
+  @Override
+  public HttpClientBuilder configure(HttpClientBuilder builder) throws Exception {
+    CredentialsProvider provider = Optional.ofNullable(getCredentialsProvider()).map(CredentialsProviderBuilder::build)
+        .orElse(new SystemDefaultCredentialsProvider());
+    builder.setDefaultCredentialsProvider(provider);
+    return builder;
+  }
+
+  public ClientBuilderWithCredentials withProvider(CredentialsProviderBuilder builder) {
+    setCredentialsProvider(builder);
+    return this;
+  }
+
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ConfiguredScope.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ConfiguredScope.java
@@ -1,0 +1,55 @@
+package interlok.http.apache.credentials;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.util.NumberUtils;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.auth.AuthScope;
+
+/** An explicitly configured {@link AuthScope} builder.
+ *
+ * @config apache-configured-authentication-scope
+ */
+@XStreamAlias("apache-configured-authentication-scope")
+@ComponentProfile(summary="Explicitly configured authentication scope")
+@NoArgsConstructor
+public class ConfiguredScope implements AuthScopeBuilder {
+
+  /** The host associated with the scope
+   *  <p>Defaults to {@code AuthScope.ANY_HOST} if not explicitly configured</p>
+   */
+  @Getter
+  @Setter
+  private String host = AuthScope.ANY_HOST;
+  /** The port associated with the scope
+   *  <p>Defaults to {@code AuthScope.ANY_PORT} if not explicitly configured</p>
+   */
+  @Getter
+  @Setter
+  private Integer port;
+  /** The realm associated with the scope
+   *  <p>Defaults to {@code AuthScope.ANY_REALM} if not explicitly configured</p>
+   *
+   */
+  @Getter
+  @Setter
+  private String realm = AuthScope.ANY_REALM;
+  /** The scheme associated with the scope
+   *  <p>Defaults to {@code AuthScope.ANY_SCHEME} if not explicitly configured</p>
+   */
+  @Getter
+  @Setter
+  private String scheme = AuthScope.ANY_SCHEME;
+
+  @Override
+  public AuthScope build() {
+    return new AuthScope(getHost(), port(), getRealm(), getScheme());
+  }
+
+  private int port() {
+    return NumberUtils.toIntDefaultIfNull(getPort(), AuthScope.ANY_PORT);
+  }
+
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsBuilder.java
@@ -1,0 +1,15 @@
+package interlok.http.apache.credentials;
+
+import org.apache.http.auth.Credentials;
+
+/**
+ * Adds support for {@code oorg.apache.http.auth.Credentials} in a configuration friendly way.
+ */
+@FunctionalInterface
+public interface CredentialsBuilder {
+
+  /**
+   * Build the {@code Credentials} object.
+   */
+  Credentials build();
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsProviderBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsProviderBuilder.java
@@ -1,0 +1,12 @@
+package interlok.http.apache.credentials;
+
+import org.apache.http.client.CredentialsProvider;
+
+@FunctionalInterface
+public interface CredentialsProviderBuilder {
+
+  /**
+   * Build the {@code org.apache.http.client.CredentialsProvider} instance.
+   */
+  CredentialsProvider build();
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsWrapper.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/CredentialsWrapper.java
@@ -1,0 +1,55 @@
+package interlok.http.apache.credentials;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+
+/**
+ * Wraps a {@code AuthScope} and {@code Credentials} for insertion into a {@code CredentialsProvider}
+ *
+ */
+@NoArgsConstructor
+@XStreamAlias("apache-http-credentials-wrapper")
+public class CredentialsWrapper {
+
+  /** The authentication scope associated with these credentials.
+   *
+   */
+  @Getter
+  @Setter
+  private AuthScopeBuilder authenticationScope;
+
+  /** The credentials.
+   *
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
+  private CredentialsBuilder credentials;
+
+  protected AuthScope authenticationScope() {
+    return ObjectUtils.defaultIfNull(getAuthenticationScope(), new AnyScope()).build();
+  }
+
+  protected Credentials credentials() {
+    return getCredentials().build();
+  }
+
+  public CredentialsWrapper withScope(AuthScopeBuilder scope) {
+    setAuthenticationScope(scope);
+    return this;
+  }
+
+  public CredentialsWrapper withCredentials(CredentialsBuilder builder) {
+    setCredentials(builder);
+    return this;
+  }
+
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
@@ -1,0 +1,48 @@
+package interlok.http.apache.credentials;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
+
+/**
+ * Supports the use of a {@code org.apache.http.client.CredentialsProvider} where supported in a configuration friendly
+ * way.
+ * <p>This uses {@code org.apache.http.impl.client.SystemDefaultCredentialsProvider} with added configuration from the
+ * underlying {@link CredentialsWrapper} via the {@code CredentialsProvider#setCredentials(AuthScope, Credentials)}
+ * method.</p>
+ *
+ * @config apache-default-credentials-provider-builder
+ */
+@XStreamAlias("apache-default-credentials-provider-builder")
+@ComponentProfile(since = "4.5.0", summary = "Supports use of 'org.apache.http.client.CredentialsProvider'")
+@NoArgsConstructor
+public class DefaultCredentialsProviderBuilder implements CredentialsProviderBuilder {
+
+  @Getter
+  @Setter
+  @NonNull
+  @NotNull
+  @XStreamImplicit(itemFieldName = "credential")
+  private List<CredentialsWrapper> credentials = new ArrayList<>();
+
+  public DefaultCredentialsProviderBuilder withCredentials(CredentialsWrapper... w) {
+    setCredentials(new ArrayList<>(List.of(w)));
+    return this;
+  }
+
+  @Override
+  public CredentialsProvider build() {
+    SystemDefaultCredentialsProvider provider = new SystemDefaultCredentialsProvider();
+    getCredentials().forEach((c) -> provider.setCredentials(c.authenticationScope(), c.credentials()));
+    return provider;
+  }
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
@@ -17,7 +17,7 @@ import org.apache.http.impl.client.SystemDefaultCredentialsProvider;
  * Supports the use of a {@code org.apache.http.client.CredentialsProvider} where supported in a configuration friendly
  * way.
  * <p>This uses {@code org.apache.http.impl.client.SystemDefaultCredentialsProvider} with added configuration from the
- * underlying {@link CredentialsWrapper} via the {@code CredentialsProvider#setCredentials(AuthScope, Credentials)}
+ * underlying {@link ScopedCredential} via the {@code CredentialsProvider#setCredentials(AuthScope, Credentials)}
  * method.</p>
  *
  * @config apache-default-credentials-provider-builder
@@ -30,19 +30,19 @@ public class DefaultCredentialsProviderBuilder implements CredentialsProviderBui
   @Getter
   @Setter
   @NonNull
-  @NotNull
-  @XStreamImplicit(itemFieldName = "credential")
-  private List<CredentialsWrapper> credentials = new ArrayList<>();
+  @NotNull(message = "No Credentials associated with a CredentialsProvider")
+  @XStreamImplicit(itemFieldName = "scoped-credential")
+  private List<ScopedCredential> scopedCredentials = new ArrayList<>();
 
-  public DefaultCredentialsProviderBuilder withCredentials(CredentialsWrapper... w) {
-    setCredentials(new ArrayList<>(List.of(w)));
+  public DefaultCredentialsProviderBuilder withScopedCredentials(ScopedCredential... w) {
+    setScopedCredentials(new ArrayList<>(List.of(w)));
     return this;
   }
 
   @Override
   public CredentialsProvider build() {
     SystemDefaultCredentialsProvider provider = new SystemDefaultCredentialsProvider();
-    getCredentials().forEach((c) -> provider.setCredentials(c.authenticationScope(), c.credentials()));
+    this.getScopedCredentials().forEach((c) -> provider.setCredentials(c.authenticationScope(), c.credentials()));
     return provider;
   }
 }

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ScopedCredential.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ScopedCredential.java
@@ -15,8 +15,8 @@ import org.apache.http.auth.Credentials;
  *
  */
 @NoArgsConstructor
-@XStreamAlias("apache-http-credentials-wrapper")
-public class CredentialsWrapper {
+@XStreamAlias("apache-http-scoped-credential")
+public class ScopedCredential {
 
   /** The authentication scope associated with these credentials.
    *
@@ -30,7 +30,7 @@ public class CredentialsWrapper {
    */
   @Getter
   @Setter
-  @NotNull
+  @NotNull(message = "No Credentials available to use")
   @NonNull
   private CredentialsBuilder credentials;
 
@@ -42,12 +42,12 @@ public class CredentialsWrapper {
     return getCredentials().build();
   }
 
-  public CredentialsWrapper withScope(AuthScopeBuilder scope) {
+  public ScopedCredential withScope(AuthScopeBuilder scope) {
     setAuthenticationScope(scope);
     return this;
   }
 
-  public CredentialsWrapper withCredentials(CredentialsBuilder builder) {
+  public ScopedCredential withCredentials(CredentialsBuilder builder) {
     setCredentials(builder);
     return this;
   }

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/UsernamePassword.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/UsernamePassword.java
@@ -1,0 +1,56 @@
+package interlok.http.apache.credentials;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.exc.PasswordException;
+import com.adaptris.security.password.Password;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+/**
+ * Adds support for {@code org.apache.http.client.CredentialsProvider} for username and password in a configuration
+ * friendly way.
+ *
+ * @config apache-username-password-credentials
+ */
+@XStreamAlias("apache-username-password-credentials")
+@DisplayOrder(order = {"username", "password"})
+@ComponentProfile(summary = "Providers username+password credentials")
+@NoArgsConstructor
+public class UsernamePassword implements CredentialsBuilder {
+
+  /**
+   * The username.
+   */
+  @Getter
+  @Setter
+  private String username;
+  /**
+   * The password.
+   * <p>The password may be encoded and/or resolved from system properties / environment variables.</p>
+   */
+  @InputFieldHint(style = "PASSWORD", external = true)
+  @Getter
+  @Setter
+  private String password;
+
+  @Override
+  @SneakyThrows(PasswordException.class)
+  public Credentials build() {
+    return new UsernamePasswordCredentials(getUsername(), Password.decode(ExternalResolver.resolve(getPassword())));
+  }
+
+  public UsernamePassword withCredentials(String user, String password) {
+    setUsername(user);
+    setPassword(password);
+    return this;
+  }
+
+}

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/UsernamePassword.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/UsernamePassword.java
@@ -7,6 +7,8 @@ import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.security.exc.PasswordException;
 import com.adaptris.security.password.Password;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,7 +19,10 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 /**
  * Adds support for {@code org.apache.http.client.CredentialsProvider} for username and password in a configuration
  * friendly way.
- *
+ * <p>This builds a {@code UsernamePasswordCredentials} under the covers, interestingly it allows you to have a non null
+ * blank username; there should be no reason why you would want to do that, so validation on the username field is set
+ * to be {@code NotBlank}.
+ * </p>
  * @config apache-username-password-credentials
  */
 @XStreamAlias("apache-username-password-credentials")
@@ -31,6 +36,7 @@ public class UsernamePassword implements CredentialsBuilder {
    */
   @Getter
   @Setter
+  @NotBlank(message="No Username associated with UsernamePassword credentials")
   private String username;
   /**
    * The password.

--- a/interlok-apache-http/src/test/java/interlok/http/apache/credentials/TestCredentialsBuilder.java
+++ b/interlok-apache-http/src/test/java/interlok/http/apache/credentials/TestCredentialsBuilder.java
@@ -17,8 +17,8 @@ public class TestCredentialsBuilder {
 
   @Test
   public void testProviderBuilder() {
-    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
-        new CredentialsWrapper().withScope(new AnyScope())
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withScopedCredentials(
+        new ScopedCredential().withScope(new AnyScope())
             .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
     );
     assertNotNull(builder.build());
@@ -27,8 +27,8 @@ public class TestCredentialsBuilder {
 
   @Test
   public void testCredentialsProvider() {
-    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
-        new CredentialsWrapper().withScope(new AnyScope())
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withScopedCredentials(
+        new ScopedCredential().withScope(new AnyScope())
             .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
     );
     CredentialsProvider provider = builder.build();
@@ -40,8 +40,8 @@ public class TestCredentialsBuilder {
 
   @Test(expected= PasswordException.class)
   public void testCredentialsProvider_BadPassword() throws Exception {
-    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
-        new CredentialsWrapper().withScope(new AnyScope())
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withScopedCredentials(
+        new ScopedCredential().withScope(new AnyScope())
             .withCredentials(new UsernamePassword().withCredentials("myUser", "AES_GCM:myPassword"))
     );
     builder.build();
@@ -65,8 +65,8 @@ public class TestCredentialsBuilder {
   public void testClientBuilderConfigure() throws Exception {
     ClientBuilderWithCredentials builder = new ClientBuilderWithCredentials();
     assertNotNull(builder.configure(HttpClients.custom()));
-    DefaultCredentialsProviderBuilder credsProvider = new DefaultCredentialsProviderBuilder().withCredentials(
-        new CredentialsWrapper().withScope(new AnyScope())
+    DefaultCredentialsProviderBuilder credsProvider = new DefaultCredentialsProviderBuilder().withScopedCredentials(
+        new ScopedCredential().withScope(new AnyScope())
             .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
     );
     assertNotNull(builder.withProvider(credsProvider).configure(HttpClients.custom()));

--- a/interlok-apache-http/src/test/java/interlok/http/apache/credentials/TestCredentialsBuilder.java
+++ b/interlok-apache-http/src/test/java/interlok/http/apache/credentials/TestCredentialsBuilder.java
@@ -1,0 +1,75 @@
+package interlok.http.apache.credentials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.adaptris.security.exc.PasswordException;
+import java.util.Locale;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Test;
+
+public class TestCredentialsBuilder {
+
+  @Test
+  public void testProviderBuilder() {
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
+        new CredentialsWrapper().withScope(new AnyScope())
+            .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
+    );
+    assertNotNull(builder.build());
+    assertTrue(CredentialsProvider.class.isAssignableFrom(builder.build().getClass()));
+  }
+
+  @Test
+  public void testCredentialsProvider() {
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
+        new CredentialsWrapper().withScope(new AnyScope())
+            .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
+    );
+    CredentialsProvider provider = builder.build();
+    Credentials creds = provider.getCredentials(AuthScope.ANY);
+    assertEquals(UsernamePasswordCredentials.class, creds.getClass());
+    assertEquals("myUser", creds.getUserPrincipal().getName());
+    assertEquals("myPassword", creds.getPassword());
+  }
+
+  @Test(expected= PasswordException.class)
+  public void testCredentialsProvider_BadPassword() throws Exception {
+    DefaultCredentialsProviderBuilder builder = new DefaultCredentialsProviderBuilder().withCredentials(
+        new CredentialsWrapper().withScope(new AnyScope())
+            .withCredentials(new UsernamePassword().withCredentials("myUser", "AES_GCM:myPassword"))
+    );
+    builder.build();
+  }
+
+  @Test
+  public void testConfiguredScope() {
+    ConfiguredScope builder = new ConfiguredScope();
+    builder.setHost("localhost");
+    builder.setPort(443);
+    builder.setRealm("realm");
+    builder.setScheme("https");
+    AuthScope scope = builder.build();
+    assertEquals("localhost", scope.getHost());
+    assertEquals(443, scope.getPort());
+    assertEquals("realm", scope.getRealm());
+    assertEquals("https".toUpperCase(Locale.ROOT), scope.getScheme().toUpperCase(Locale.ROOT));
+  }
+
+  @Test
+  public void testClientBuilderConfigure() throws Exception {
+    ClientBuilderWithCredentials builder = new ClientBuilderWithCredentials();
+    assertNotNull(builder.configure(HttpClients.custom()));
+    DefaultCredentialsProviderBuilder credsProvider = new DefaultCredentialsProviderBuilder().withCredentials(
+        new CredentialsWrapper().withScope(new AnyScope())
+            .withCredentials(new UsernamePassword().withCredentials("myUser", "myPassword"))
+    );
+    assertNotNull(builder.withProvider(credsProvider).configure(HttpClients.custom()));
+  }
+
+}


### PR DESCRIPTION
## Motivation

This is related to https://github.com/adaptris/interlok-elastic/issues/269. There needs to be a configuration friendly way to configure this, since we don't want to duplicate code to handle configuring the `HttpClientBuilder` with a `CredentialsProvider`

## Modification

Added concrete implementation of `HttpClientConfigurator` that can configure a HttpClientBuilder with a default CredentialsProvider
Add supporting classes for `ClientBuilderWithCredentials` that should allow us to configure _elastic-rest_ in a configuration friendly way with a username+password.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

You can now configure a `credentials-provider-apache-http-client-builder` when you configure ApacheHttpProducer. 

Note that by default `DefaultClientBuilder` will actually add a `SystemDefaultCredentialsProvider` as its last action when configuring the underlying builder; this means that if you wish to chain builders together, then the new _ClientBuilderWithCredentials_ needs to be after it in a _CompositeClientBuilder_

## Testing

This is somewhat forced, because generally we actually want to configure a HttpAuthenticator on the producer rather than configuring the builder with a default; however, you can do it.

- Have something that requires a username and password to connect via HTTP
- Select a new apache-http-producer; switch to advanced mode, and configure the new builder. Make sure you don't configure any kind of other authentication
- Test it.
