### PR TITLE
Switch to lombok for apache-http

### DIFF
--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ApacheRequestAuthenticator.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ApacheRequestAuthenticator.java
@@ -9,7 +9,7 @@ import com.adaptris.core.http.auth.HttpAuthenticator;
  * Some implementations of this interface will need to temporarily mutate global state and therefore must be closed in a finally
  * statement or try-with-resources block.
  * </p>
- * 
+ *
  * @author gdries
  */
 public interface ApacheRequestAuthenticator extends HttpAuthenticator {
@@ -17,6 +17,6 @@ public interface ApacheRequestAuthenticator extends HttpAuthenticator {
   /**
    * Perform whatever actions are required to the HttpRequestBase.
    */
-  public void configure(HttpRequestBase req) throws Exception;
+  void configure(HttpRequestBase req) throws Exception;
 
 }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/BranchingHttpRequestService.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/BranchingHttpRequestService.java
@@ -78,7 +78,7 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
    * Set the {@code nextServiceId} based on these evaluators.
    *
    */
-  @NotNull
+  @NotNull(message="List of HTTP response code evaluators may not be null")
   @AutoPopulated
   @Valid
   @XStreamImplicit
@@ -100,7 +100,7 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
 
   public BranchingHttpRequestService() {
     super();
-    setStatusMatches(new ArrayList<StatusEvaluator>());
+    setStatusMatches(new ArrayList<>());
   }
 
   public BranchingHttpRequestService(String url) {
@@ -124,8 +124,8 @@ public class BranchingHttpRequestService extends HttpRequestServiceImpl {
     p.setIgnoreServerResponseCode(true);
     try {
       LifecycleHelper.initAndStart(p).request(msg);
-      Optional.ofNullable(getDefaultServiceId()).ifPresent((s) -> msg.setNextServiceId(s));
-      int responseCode = ((Integer) msg.getObjectHeaders().get(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE)).intValue();
+      Optional.ofNullable(getDefaultServiceId()).ifPresent(msg::setNextServiceId);
+      int responseCode = (Integer) msg.getObjectHeaders().get(CoreConstants.HTTP_PRODUCER_RESPONSE_CODE);
       for (StatusEvaluator rp : getStatusMatches()) {
         if (rp.matches(responseCode)) {
           msg.setNextServiceId(rp.serviceId());

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeClientBuilder.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeClientBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,21 +15,23 @@
 */
 package com.adaptris.core.http.apache;
 
+import com.adaptris.annotation.AutoPopulated;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 import org.apache.http.impl.client.HttpClientBuilder;
-
-import com.adaptris.core.util.Args;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * {@link HttpClientBuilderConfigurator} implementation that wraps a list of implementations.
- * 
+ *
  * @config composite-apache-http-client-builder
  * @see CustomTlsBuilder
  * @see DefaultClientBuilder
@@ -37,24 +39,22 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * @see RequestInterceptorClientBuilder
  */
 @XStreamAlias("composite-apache-http-client-builder")
+@NoArgsConstructor
 public class CompositeClientBuilder implements HttpClientBuilderConfigurator {
 
-  @NotNull
+  /** The list of builders that will be used in turn to configure the {@code HttpClientBuilder}.
+   *
+   */
+  @NotNull(message="Use an empty list of builders, not null")
+  @NonNull
   @XStreamImplicit
-  private List<HttpClientBuilderConfigurator> builders;
+  @Valid
+  @Getter
+  @Setter
+  @AutoPopulated
+  private List<HttpClientBuilderConfigurator> builders = new ArrayList<>();
 
-  public CompositeClientBuilder() {
-    setBuilders(new ArrayList<>());
-  }
-
-  public List<HttpClientBuilderConfigurator> getBuilders() {
-    return builders;
-  }
-
-  public void setBuilders(List<HttpClientBuilderConfigurator> list) {
-    this.builders = Args.notNull(list, "builders");
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CompositeClientBuilder> T withBuilders(HttpClientBuilderConfigurator... builders) {
     this.builders = new ArrayList<>(Arrays.asList(builders));
     return (T) this;

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeRequestHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeRequestHeaders.java
@@ -3,8 +3,13 @@ package com.adaptris.core.http.apache;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 import org.apache.http.client.methods.HttpRequestBase;
 
 import com.adaptris.annotation.AutoPopulated;
@@ -16,26 +21,30 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
 /**
  * Implementation of {@link RequestHeaderProvider} that uses its own configured handlers to add headers.
- * 
+ *
  * <p>
  * This implementation is primarily so that you can mix and match both static and metadata driven headers; the order in which you
  * configure them determines what is actually present as headers.
  * </p>
- * 
+ *
  * @config apache-http-composite-request-headers
- * 
+ *
  */
 @XStreamAlias("apache-http-composite-request-headers")
+@NoArgsConstructor
 public class CompositeRequestHeaders implements RequestHeaderProvider<HttpRequestBase> {
+
+  /** The list of {@link RequestHeaderProvider}s to apply to the HTTP Request.
+   *
+   */
+  @Valid
+  @Getter
+  @Setter
   @XStreamImplicit
-  @NotNull
+  @NotNull(message="Use an empty list of RequestHeaderProviders, not null")
+  @NonNull
   @AutoPopulated
-  private List<RequestHeaderProvider<HttpRequestBase>> providers;
-
-  public CompositeRequestHeaders() {
-    providers = new ArrayList<>();
-  }
-
+  private List<RequestHeaderProvider<HttpRequestBase>> providers = new ArrayList<>();
 
   @Override
   public HttpRequestBase addHeaders(AdaptrisMessage msg, HttpRequestBase target) {
@@ -44,16 +53,6 @@ public class CompositeRequestHeaders implements RequestHeaderProvider<HttpReques
       http = h.addHeaders(msg, http);
     }
     return http;
-  }
-
-
-  public List<RequestHeaderProvider<HttpRequestBase>> getProviders() {
-    return providers;
-  }
-
-
-  public void setProviders(List<RequestHeaderProvider<HttpRequestBase>> handlers) {
-    this.providers = Args.notNull(handlers, "Request Header Providers");
   }
 
   public void addHandler(RequestHeaderProvider<HttpRequestBase> handler) {

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeResponseHeaderHandler.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CompositeResponseHeaderHandler.java
@@ -1,55 +1,53 @@
 package com.adaptris.core.http.apache;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.HttpResponse;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.http.client.ResponseHeaderHandler;
 import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.http.HttpResponse;
 
 /**
  * Implementation of {@link ResponseHeaderHandler} that uses nested handlers to extract headers from a {@link
  * HttpResponse}.
- * 
- * <p>This implementation is primarily so that you can mix and matchhow you capture response headers; If you wanted to use both
+ *
+ * <p>This implementation is primarily so that you can mix and match how you capture response headers; If you wanted to use both
  * {@link ResponseHeadersAsMetadata} and {@link ResponseHeadersAsObjectMetadata} then you can.
  * </p>
  * @config apache-http-composite-request-headers
- * 
+ *
  */
 @XStreamAlias("apache-http-composite-response-header-handler")
+@NoArgsConstructor
 public class CompositeResponseHeaderHandler implements ResponseHeaderHandler<HttpResponse> {
+
+  /** The list of {@link ResponseHeaderHandler} objects that will be used to process
+   *  HTTP Response headers.
+   */
   @XStreamImplicit
-  @NotNull
+  @NotNull(message="Use an empty list of ResponseHeaderHandlers, not null")
+  @NonNull
   @AutoPopulated
-  private List<ResponseHeaderHandler<HttpResponse>> handlers;
+  @Valid
+  @Getter
+  @Setter
+  private List<ResponseHeaderHandler<HttpResponse>> handlers = new ArrayList<>();
 
-  public CompositeResponseHeaderHandler() {
-    setHandlers(new ArrayList<ResponseHeaderHandler<HttpResponse>>());
-  }
-
+  @SafeVarargs
   public CompositeResponseHeaderHandler(ResponseHeaderHandler<HttpResponse>... handlers) {
     this();
     for (ResponseHeaderHandler<HttpResponse> h : handlers) {
       addHandler(h);
     }
-  }
-
-
-
-  public List<ResponseHeaderHandler<HttpResponse>> getHandlers() {
-    return handlers;
-  }
-
-  public void setHandlers(List<ResponseHeaderHandler<HttpResponse>> handlers) {
-    this.handlers = Args.notNull(handlers, "Response Header Handlers");
   }
 
   public void addHandler(ResponseHeaderHandler<HttpResponse> handler) {

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ConfiguredAuthorizationHeader.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ConfiguredAuthorizationHeader.java
@@ -1,14 +1,16 @@
 package com.adaptris.core.http.apache;
 
-import javax.validation.constraints.NotBlank;
-import org.apache.http.client.methods.HttpRequestBase;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.http.HttpConstants;
 import com.adaptris.core.http.auth.ResourceTargetMatcher;
-import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Build an {@link HttpConstants#AUTHORIZATION} header from static data.
@@ -16,33 +18,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @config apache-http-configured-authorization-header
  */
 @XStreamAlias("apache-http-configured-authorization-header")
+@NoArgsConstructor
 public class ConfiguredAuthorizationHeader implements ApacheRequestAuthenticator {
 
-  @NotBlank
+  @Getter
+  @Setter
+  @NotBlank(message="Authorization Header Value should not be blank")
   @InputFieldHint(expression = true)
   private String headerValue;
 
   private transient String actualHeaderValue;
 
-  public ConfiguredAuthorizationHeader() {
-
-  }
-
   public ConfiguredAuthorizationHeader(String value) {
     this();
     setHeaderValue(value);
-  }
-
-  public String getHeaderValue() {
-    return headerValue;
-  }
-
-  /**
-   * The value for the authorization header
-   * @param headerValue
-   */
-  public void setHeaderValue(String headerValue) {
-    this.headerValue = Args.notBlank(headerValue, "headerValue");
   }
 
   @Override

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ConfiguredRequestHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ConfiguredRequestHeaders.java
@@ -1,33 +1,35 @@
 package com.adaptris.core.http.apache;
 
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.client.methods.HttpRequestBase;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.http.client.RequestHeaderProvider;
-import com.adaptris.core.util.Args;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Implementation of {@link RequestHeaderProvider} that applies static configured values as headers.
- * 
+ *
  * @config apache-http-configured-request-headers
- * 
+ *
  */
 @XStreamAlias("apache-http-configured-request-headers")
+@NoArgsConstructor
 public class ConfiguredRequestHeaders implements RequestHeaderProvider<HttpRequestBase> {
-  @NotNull
+
+  /** The list of headers to add to the request.
+   *
+   */
+  @Getter
+  @Setter
+  @NotNull(message="Use an empty set, not null for headers")
   @AutoPopulated
-  private KeyValuePairSet headers;
-
-  public ConfiguredRequestHeaders() {
-    headers = new KeyValuePairSet();
-  }
-
+  private KeyValuePairSet headers = new KeyValuePairSet();
 
   @Override
   public HttpRequestBase addHeaders(AdaptrisMessage msg, HttpRequestBase target) {
@@ -35,15 +37,6 @@ public class ConfiguredRequestHeaders implements RequestHeaderProvider<HttpReque
       target.addHeader(k.getKey(), k.getValue());
     }
     return target;
-  }
-
-
-  public KeyValuePairSet getHeaders() {
-    return headers;
-  }
-
-  public void setHeaders(KeyValuePairSet headers) {
-    this.headers = Args.notNull(headers, "headers");
   }
 
   public ConfiguredRequestHeaders withHeaders(KeyValuePair... keyValuePairs) {

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CustomTlsBuilder.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/CustomTlsBuilder.java
@@ -1,27 +1,38 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 package com.adaptris.core.http.apache;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.security.PrivateKeyPasswordProvider;
+import com.adaptris.security.exc.AdaptrisSecurityException;
+import com.adaptris.security.keystore.ConfiguredKeystore;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.validation.Valid;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -30,40 +41,32 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.ssl.TrustStrategy;
-import com.adaptris.annotation.AdvancedConfig;
-import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.core.security.PrivateKeyPasswordProvider;
-import com.adaptris.security.exc.AdaptrisSecurityException;
-import com.adaptris.security.keystore.ConfiguredKeystore;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * {@link HttpClientBuilderConfigurator} implementation that allows you to customise keystores etc.
- * 
- * @config custom-tls-apache-http-client-builder
  *
+ * @config custom-tls-apache-http-client-builder
  */
 @DisplayOrder(order =
-{
-    "keystore", "privateKeyPassword", "truststore", "hostnameVerification", "tlsVersions", "cipherSuites"
-})
+    {
+        "keystore", "privateKeyPassword", "truststore", "hostnameVerification", "tlsVersions", "cipherSuites"
+    })
 @XStreamAlias("custom-tls-apache-http-client-builder")
+@NoArgsConstructor
 public class CustomTlsBuilder implements HttpClientBuilderConfigurator {
-  public static enum HostnameVerification {
+  public enum HostnameVerification {
     /**
      * No Hostname Verification (dangerous).
-     * 
      */
     NONE(new NoopHostnameVerifier()),
     /**
      * Standard Hostname verification
-     * 
      */
     STANDARD(SSLConnectionSocketFactory.getDefaultHostnameVerifier());
 
-    private HostnameVerifier myVerifier;
+    private final HostnameVerifier myVerifier;
 
-    private HostnameVerification(HostnameVerifier v) {
+    HostnameVerification(HostnameVerifier v) {
       myVerifier = v;
     }
 
@@ -73,28 +76,71 @@ public class CustomTlsBuilder implements HttpClientBuilderConfigurator {
 
   }
 
+  /**
+   * The list of tls versions that will be supported (comma separated)
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   private String tlsVersions;
+  /**
+   * The cipher suites to support (comma separated)
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
   private String cipherSuites;
+  /** How we want to verify the hostname.
+   * <p>Defaults to {@link HostnameVerification#STANDARD} if not explicitly specified.</p>
+   */
+  @Getter
+  @Setter
   @AdvancedConfig
+  @InputFieldDefault(value = "STANDARD")
   private HostnameVerification hostnameVerification;
+  /** The truststore used with TLS
+   *
+   */
+  @Getter
+  @Setter
   @Valid
   private ConfiguredKeystore truststore;
+  /** The keystore used with TLS.
+   *
+   */
+  @Getter
+  @Setter
   @Valid
   private ConfiguredKeystore keystore;
+  /** The private key password.
+   *
+   */
+  @Getter
+  @Setter
   @Valid
   private PrivateKeyPasswordProvider privateKeyPassword;
+  /** Whether or not to trust self signed certificates.
+   *  <p>Defaults to false if not explicitly configured.</p>
+   */
+  @InputFieldDefault(value = "false")
+  @Getter
+  @Setter
   private Boolean trustSelfSigned;
+
+  private static String[] asArray(String s) {
+    if (isEmpty(s)) {
+      return null;
+    }
+    return s.split("\\s*,\\s*", -1);
+  }
 
   @Override
   public HttpClientBuilder configure(HttpClientBuilder builder) throws Exception {
-    HttpClientBuilder result = builder;
     SSLContext sslcontext = configure(SSLContexts.custom()).build();
     SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslcontext, asArray(getTlsVersions()),
         asArray(getCipherSuites()), hostnameVerification().getVerifier());
-    result.setSSLSocketFactory(sslsf);
-    return result;
+    builder.setSSLSocketFactory(sslsf);
+    return builder;
   }
 
   private SSLContextBuilder configure(SSLContextBuilder builder)
@@ -113,67 +159,19 @@ public class CustomTlsBuilder implements HttpClientBuilderConfigurator {
     return builder;
   }
 
-  private static String[] asArray(String s) {
-    if (isEmpty(s)) {
-      return null;
-    }
-    return s.split("\\s*,\\s*", -1);
-  }
-
-  public String getTlsVersions() {
-    return tlsVersions;
-  }
-
-  /**
-   * 
-   * Set the list of tls versions that will be supported (comma separated)
-   * 
-   * @param tls the tls versions to support; default is null
-   */
-  public void setTlsVersions(String tls) {
-    this.tlsVersions = tls;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withTlsVersions(String s) {
     setTlsVersions(s);
     return (T) this;
   }
 
-  /**
-   * @return the cipherSuites
-   */
-  public String getCipherSuites() {
-    return cipherSuites;
-  }
-
-  /**
-   * Set the cipher suites to support.
-   * 
-   * @param ciphers the cipherSuites to support; default is null
-   */
-  public void setCipherSuites(String ciphers) {
-    this.cipherSuites = ciphers;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withCipherSuites(String s) {
     setCipherSuites(s);
     return (T) this;
   }
 
-  /**
-   * @return the hostnameVerification
-   */
-  public HostnameVerification getHostnameVerification() {
-    return hostnameVerification;
-  }
-
-  /**
-   * @param hostnameVerification the hostnameVerification to set
-   */
-  public void setHostnameVerification(HostnameVerification hostnameVerification) {
-    this.hostnameVerification = hostnameVerification;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withHostnameVerification(HostnameVerification s) {
     setHostnameVerification(s);
     return (T) this;
@@ -183,23 +181,11 @@ public class CustomTlsBuilder implements HttpClientBuilderConfigurator {
     return getHostnameVerification() != null ? getHostnameVerification() : HostnameVerification.STANDARD;
   }
 
-  public Boolean getTrustSelfSigned() {
-    return trustSelfSigned;
-  }
-
-  /**
-   * Do we trust self-signed certificates or not.
-   * 
-   * @param b if set to true the {@code TrustSelfSignedStrategy.INSTANCE} is used; default null/false.
-   */
-  public void setTrustSelfSigned(Boolean b) {
-    this.trustSelfSigned = b;
-  }
-
   protected boolean trustSelfSigned() {
     return BooleanUtils.toBooleanDefaultIfNull(getTrustSelfSigned(), false);
   }
 
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withTrustSelfSigned(Boolean s) {
     setTrustSelfSigned(s);
     return (T) this;
@@ -209,48 +195,19 @@ public class CustomTlsBuilder implements HttpClientBuilderConfigurator {
     return trustSelfSigned() ? TrustSelfSignedStrategy.INSTANCE : null;
   }
 
-  public PrivateKeyPasswordProvider getPrivateKeyPassword() {
-    return privateKeyPassword;
-  }
-
-  public void setPrivateKeyPassword(PrivateKeyPasswordProvider pk) {
-    this.privateKeyPassword = pk;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withPrivateKeyPassword(PrivateKeyPasswordProvider s) {
     setPrivateKeyPassword(s);
     return (T) this;
   }
 
-  public ConfiguredKeystore getTruststore() {
-    return truststore;
-  }
-
-  /**
-   * Set the trustore to be used.
-   * 
-   */
-  public void setTruststore(ConfiguredKeystore truststore) {
-    this.truststore = truststore;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withTrustStore(ConfiguredKeystore s) {
     setTruststore(s);
     return (T) this;
   }
 
-  public ConfiguredKeystore getKeystore() {
-    return keystore;
-  }
-
-  /**
-   * Set the keystore to be used.
-   * 
-   */
-  public void setKeystore(ConfiguredKeystore keystore) {
-    this.keystore = keystore;
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends CustomTlsBuilder> T withKeystore(ConfiguredKeystore s) {
     setKeystore(s);
     return (T) this;

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DiscardResponseHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DiscardResponseHeaders.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.apache;
 
+import lombok.NoArgsConstructor;
 import org.apache.http.HttpResponse;
 
 import com.adaptris.core.AdaptrisMessage;
@@ -8,11 +9,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * {@link ResponseHeaderHandler} implementation that discards the headers from the HTTP response.
- * 
- * @author lchan
+ *
  * @config apache-http-discard-response-headers
  */
 @XStreamAlias("apache-http-discard-response-headers")
+@NoArgsConstructor
 public class DiscardResponseHeaders implements ResponseHeaderHandler<HttpResponse> {
 
   @Override

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DynamicBasicAuthorizationHeader.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/DynamicBasicAuthorizationHeader.java
@@ -1,10 +1,5 @@
 package com.adaptris.core.http.apache;
 
-import java.io.UnsupportedEncodingException;
-import java.net.PasswordAuthentication;
-import java.net.URLConnection;
-import javax.validation.constraints.NotBlank;
-import org.apache.http.client.methods.HttpRequestBase;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
@@ -18,6 +13,14 @@ import com.adaptris.security.exc.PasswordException;
 import com.adaptris.security.password.Password;
 import com.adaptris.util.text.Base64ByteTranslator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import java.net.PasswordAuthentication;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Build a {@link HttpConstants#AUTHORIZATION} (Basic only) from configuration (or metadata).
@@ -31,20 +34,27 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *
  */
 @XStreamAlias("apache-http-dynamic-authorization-header")
+@NoArgsConstructor
 public class DynamicBasicAuthorizationHeader implements ApacheRequestAuthenticator {
 
-  @NotBlank
+  /** The username.
+   *
+   */
+  @Getter
+  @Setter
+  @NotBlank(message="username may not be blank for authorization")
   @InputFieldHint(expression = true)
   private String username;
-  @NotBlank
+  /** The password.
+   *
+   */
+  @Getter
+  @Setter
+  @NotBlank(message="password may not be blank for authorization")
   @InputFieldHint(expression = true, style = "PASSWORD", external = true)
   private String password;
 
   private transient String authHeader;
-
-  public DynamicBasicAuthorizationHeader() {
-
-  }
 
   public DynamicBasicAuthorizationHeader(String username, String password) {
     this();
@@ -57,9 +67,11 @@ public class DynamicBasicAuthorizationHeader implements ApacheRequestAuthenticat
     try {
       String username = Args.notBlank(msg.resolve(getUsername()), "username");
       String password = Args.notBlank(msg.resolve(ExternalResolver.resolve(getPassword())), "password");
-      String encoded = new Base64ByteTranslator().translate(String.format("%s:%s", username, Password.decode(password)).getBytes("UTF-8"));
+      String encoded = new Base64ByteTranslator().translate(
+          String.format("%s:%s", username, Password.decode(password)).getBytes(
+              StandardCharsets.UTF_8));
       authHeader = String.format("Basic %s", encoded);
-    } catch (UnsupportedEncodingException | IllegalArgumentException | PasswordException e) {
+    } catch (IllegalArgumentException | PasswordException e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
   }
@@ -71,31 +83,6 @@ public class DynamicBasicAuthorizationHeader implements ApacheRequestAuthenticat
 
   @Override
   public void close() {
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  /**
-   * Set the username
-   */
-  public void setUsername(String s) {
-    username = Args.notBlank(s, "username");
-  }
-
-  /**
-   * @return the password
-   */
-  public String getPassword() {
-    return password;
-  }
-
-  /**
-   * @param pw the password to set
-   */
-  public void setPassword(String pw) {
-    password = Args.notBlank(pw, "password");
   }
 
 }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpRequestService.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/HttpRequestService.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2017 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,10 +27,11 @@ import com.adaptris.core.StandaloneRequestor;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * Direct HTTP support as a service rather wrapped via {@link StandaloneProducer} or {@link StandaloneRequestor}.
- * 
+ *
  * <p>
  * Note that this service just wraps a {@link ApacheHttpProducer} instance but doesn't expose all the possible settings available
  * for the normal {@link ApacheHttpProducer}. If you need those features, than continue using the producer wrapped as a
@@ -41,7 +42,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * values as part of a constant string e.g. {@code setUrl("%message{http_url}")} will use the metadata value associated with the key
  * {@code http_url}.
  * </p>
- * 
+ *
  * @config apache-http-request-service
  */
 @XStreamAlias("apache-http-request-service")
@@ -52,12 +53,9 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 }, author = "Adaptris Ltd")
 @DisplayOrder(order = {"url", "method", "contentType", "authenticator", "requestHeaderProvider", "responseHeaderHandler"})
+@NoArgsConstructor
 public class HttpRequestService extends HttpRequestServiceImpl implements DynamicPollingTemplate.TemplateProvider {
 
-  public HttpRequestService() {
-    super();
-  }
-  
   public HttpRequestService(String url) {
     this();
     setUrl(url);

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/MetadataRequestHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/MetadataRequestHeaders.java
@@ -1,33 +1,37 @@
 package com.adaptris.core.http.apache;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.client.methods.HttpRequestBase;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
 import com.adaptris.core.http.client.RequestHeaderProvider;
 import com.adaptris.core.metadata.MetadataFilter;
-import com.adaptris.core.util.Args;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import javax.validation.Valid;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Implementation of {@link RequestHeaderProvider} that applies {@link AdaptrisMessage} metadata as headers using a
  * {@link MetadataFilter}.
- * 
+ *
  * @config apache-http-metadata-request-headers
- * 
+ *
  */
 @XStreamAlias("apache-http-metadata-request-headers")
+@NoArgsConstructor
 public class MetadataRequestHeaders implements RequestHeaderProvider<HttpRequestBase> {
-  @NotNull
+
+  /** Apply a filter to the metadata before adding metadata as HTTP headers.
+   *  <p>If not explicitly configured, then defaults to {@link RemoveAllMetadataFilter}</p>
+   */
+  @Getter
+  @Setter
   @Valid
   private MetadataFilter filter;
-
-  public MetadataRequestHeaders() {
-  }
 
   public MetadataRequestHeaders(MetadataFilter mf) {
     this();
@@ -36,19 +40,14 @@ public class MetadataRequestHeaders implements RequestHeaderProvider<HttpRequest
 
   @Override
   public HttpRequestBase addHeaders(AdaptrisMessage msg, HttpRequestBase target) {
-    MetadataCollection metadataSubset = getFilter().filter(msg);
+    MetadataCollection metadataSubset = filter().filter(msg);
     for (MetadataElement me : metadataSubset) {
       target.addHeader(me.getKey(), me.getValue());
     }
     return target;
   }
 
-  public MetadataFilter getFilter() {
-    return filter;
+  protected MetadataFilter filter() {
+    return ObjectUtils.defaultIfNull(getFilter(), new RemoveAllMetadataFilter());
   }
-
-  public void setFilter(MetadataFilter filter) {
-    this.filter = Args.notNull(filter, "metadata filter");
-  }
-
 }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/MetadataResponseHandlerFactory.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/MetadataResponseHandlerFactory.java
@@ -30,7 +30,10 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor
 public class MetadataResponseHandlerFactory extends ResponseHandlerFactoryImpl {
 
-  @NotBlank
+  /** The metadata key to store the response against.
+   *
+   */
+  @NotBlank(message="metadataKey for the HTTP response may not be blank")
   @Getter
   @Setter
   private String metadataKey;

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/NoConnectionManagement.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/NoConnectionManagement.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 */
 package com.adaptris.core.http.apache;
 
+import lombok.NoArgsConstructor;
 import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
@@ -32,20 +33,20 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * <li>{@code HttpClientBuilder#setConnectionReuseStrategy(ConnectionReuseStrategy)} =
  * {@code NoConnectionReuseStrategy#INSTANCE}</li>
  * </ul>
- * 
+ *
  * @config no-connection-management-apache-http-client-builder
  *
  */
 @XStreamAlias("no-connection-management-apache-http-client-builder")
+@NoArgsConstructor
 public class NoConnectionManagement implements HttpClientBuilderConfigurator {
 
   @Override
   public HttpClientBuilder configure(HttpClientBuilder builder) throws Exception {
-    HttpClientBuilder result = builder;
-    result.setConnectionManagerShared(false);
-    result.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
-    result.setConnectionManager(new BasicHttpClientConnectionManager());
-    return result;
+    builder.setConnectionManagerShared(false);
+    builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+    builder.setConnectionManager(new BasicHttpClientConnectionManager());
+    return builder;
   }
 
 }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/NoOpRequestHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/NoOpRequestHeaders.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.apache;
 
+import lombok.NoArgsConstructor;
 import org.apache.http.client.methods.HttpRequestBase;
 
 import com.adaptris.core.AdaptrisMessage;
@@ -8,12 +9,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Implementation of {@link RequestHeaderProvider} that adds no additional headers
- * 
+ *
  * @config apache-http-no-request-headers
- * @author lchan
- * 
  */
 @XStreamAlias("apache-http-no-request-headers")
+@NoArgsConstructor
 public class NoOpRequestHeaders implements RequestHeaderProvider<HttpRequestBase> {
 
 

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/RequestInterceptorClientBuilder.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/RequestInterceptorClientBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,10 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.adaptris.annotation.AdvancedConfig;
@@ -32,29 +36,21 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 /**
  * {@link HttpClientBuilderConfigurator} instance that allows additional {@code HttpRequestInterceptor} instances to be added to the
  * outgoing request.
- * 
+ *
  * @config request-interceptor-apache-http-client-builder
  */
 @XStreamAlias("request-interceptor-apache-http-client-builder")
+@NoArgsConstructor
 public class RequestInterceptorClientBuilder implements HttpClientBuilderConfigurator {
 
-  @AdvancedConfig
+  /** Additional request interceptors that will be added to the {@link HttpClientBuilder}.
+   *
+   */
+  @Getter
+  @Setter
   @Valid
   @XStreamImplicit
   private List<RequestInterceptorBuilder> requestInterceptors;
-
-  public List<RequestInterceptorBuilder> getRequestInterceptors() {
-    return requestInterceptors;
-  }
-
-  /**
-   * Set any additional request interceptors that will be added to the {@link HttpClientBuilder}.
-   * 
-   * @param list
-   */
-  public void setRequestInterceptors(List<RequestInterceptorBuilder> list) {
-    this.requestInterceptors = list;
-  }
 
   public RequestInterceptorClientBuilder withInterceptors(RequestInterceptorBuilder... interceptors) {
     setRequestInterceptors(new ArrayList<>(Arrays.asList(interceptors)));
@@ -62,7 +58,7 @@ public class RequestInterceptorClientBuilder implements HttpClientBuilderConfigu
   }
 
   protected List<RequestInterceptorBuilder> requestInterceptors() {
-    return getRequestInterceptors() != null ? getRequestInterceptors() : Collections.emptyList();
+    return ObjectUtils.defaultIfNull(getRequestInterceptors(), Collections.emptyList());
   }
 
   @Override

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactory.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHandlerFactory.java
@@ -13,7 +13,7 @@ public interface ResponseHandlerFactory {
   /**
    * Key in object metadata that tells us if the payload has been modified by the ResponseHandler.
    */
-  public static final String OBJ_METADATA_PAYLOAD_MODIFIED =
+  String OBJ_METADATA_PAYLOAD_MODIFIED =
       ResponseHandler.class.getSimpleName() + "_modifiedPayload";
 
 

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHeadersAsMetadata.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHeadersAsMetadata.java
@@ -1,6 +1,11 @@
 package com.adaptris.core.http.apache;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.slf4j.Logger;
@@ -12,21 +17,22 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Concrete implementation of {@link ResponseHeaderHandler} which adds all the HTTP headers from the
  * response as metadata to the {@link AdaptrisMessage}.
- * 
+ *
  * @config apache-http-response-headers-as-metadata
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("apache-http-response-headers-as-metadata")
+@NoArgsConstructor
 public class ResponseHeadersAsMetadata implements ResponseHeaderHandler<HttpResponse> {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass());
 
+  /** The metadata prefix to add to any metadata recorded from the HTTP response headers.
+   */
+  @Getter
+  @Setter
   private String metadataPrefix;
-
-  public ResponseHeadersAsMetadata() {
-
-  }
 
   public ResponseHeadersAsMetadata(String prefix) {
     this();
@@ -51,20 +57,7 @@ public class ResponseHeadersAsMetadata implements ResponseHeaderHandler<HttpResp
     return defaultIfEmpty(getMetadataPrefix(), "") + header;
   }
 
-  public String getMetadataPrefix() {
-    return metadataPrefix;
-  }
-
-  public void setMetadataPrefix(String metadataPrefix) {
-    this.metadataPrefix = metadataPrefix;
-  }
-
-
   protected static boolean notNull(Object[] o) {
-    boolean result = true;
-    if (o == null || o.length == 0) {
-      result = false;
-    }
-    return result;
+    return ArrayUtils.isNotEmpty(o);
   }
 }

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHeadersAsObjectMetadata.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/ResponseHeadersAsObjectMetadata.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.http.apache;
 
+import lombok.NoArgsConstructor;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 
@@ -10,20 +11,17 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 /**
  * Concrete implementation of {@link ResponseHeaderHandler} which adds all the HTTP headers from the
  * response as object metadata to the {@link AdaptrisMessage}.
- * 
+ *
  * <p>The underlying {@link Header} object that will be added to object metadata and keyed by {@link Header#getName}. and will
  * include header fields where the name is {@code null};
  * </p>
  * @config apache-http-response-headers-as-object-metadata
  * @author lchan
- * 
+ *
  */
 @XStreamAlias("apache-http-response-headers-as-object-metadata")
+@NoArgsConstructor
 public class ResponseHeadersAsObjectMetadata extends ResponseHeadersAsMetadata {
-
-  public ResponseHeadersAsObjectMetadata() {
-
-  }
 
   public ResponseHeadersAsObjectMetadata(String prefix) {
     this();
@@ -31,7 +29,7 @@ public class ResponseHeadersAsObjectMetadata extends ResponseHeadersAsMetadata {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({ "deprecation", "unchecked"} )
   public AdaptrisMessage handle(HttpResponse src, AdaptrisMessage msg) {
     Header[] headers = src.getAllHeaders();
     if (notNull(headers)) {

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/AcceptEncoding.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/AcceptEncoding.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,52 +15,42 @@
 */
 package com.adaptris.core.http.apache.request;
 
+import com.adaptris.annotation.AutoPopulated;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.client.protocol.RequestAcceptEncoding;
 
-import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.core.util.Args;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamImplicit;
-
 /**
  * Add an {@code Accept-Encoding} header to the outgoing request via {@link RequestAcceptEncoding}.
- * 
+ *
  * @config apache-http-accept-encoding
  */
 @XStreamAlias("apache-http-accept-encoding")
+@NoArgsConstructor
 public class AcceptEncoding implements RequestInterceptorBuilder {
 
   @XStreamImplicit(itemFieldName = "accept-encoding")
-  @NotNull
+  @NotNull(message="acceptEncodings may not be null")
   @AutoPopulated
-  private List<String> acceptEncodings;
+  @Getter
+  @Setter
+  private List<String> acceptEncodings = new ArrayList<>();
 
-  public AcceptEncoding() {
-    setAcceptEncodings(new ArrayList());
-  }
 
   public AcceptEncoding(String... list) {
-    this(new ArrayList<String>(Arrays.asList(list)));
+    this(new ArrayList<>(List.of(list)));
   }
 
   public AcceptEncoding(List<String> list) {
     this();
     setAcceptEncodings(list);
-  }
-
-  public List<String> getAcceptEncodings() {
-    return acceptEncodings;
-  }
-
-  public void setAcceptEncodings(List<String> l) {
-    this.acceptEncodings = Args.notNull(l, "acceptEncodings");
   }
 
   @Override

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/BasicHMACSignature.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/BasicHMACSignature.java
@@ -17,6 +17,9 @@ package com.adaptris.core.http.apache.request;
 
 import java.util.List;
 import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.protocol.HttpContext;
@@ -44,18 +47,18 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @config apache-http-basic-hmac-signature
  */
 @XStreamAlias("apache-http-basic-hmac-signature")
+@NoArgsConstructor
 public class BasicHMACSignature extends HMACSignatureImpl {
-  @NotBlank
+
+  /** The identity to use for the HMAC.
+   *
+   */
+  @NotBlank(message="identity may not be blank for HMAC generation")
+  @Getter
+  @Setter
   private String identity;
 
-  public String getIdentity() {
-    return identity;
-  }
-
-  public void setIdentity(String identity) {
-    this.identity = Args.notBlank(identity, "identity");
-  }
-
+  @SuppressWarnings("unchecked")
   public <T extends BasicHMACSignature> T withIdentity(String s) {
     setIdentity(s);
     return (T) this;

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/DateHeader.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/DateHeader.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 */
 package com.adaptris.core.http.apache.request;
 
+import lombok.NoArgsConstructor;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.RequestDate;
 
@@ -22,10 +23,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Adds a Date header via {@code RequestDate}.
- * 
+ *
  * @config apache-http-add-date-to-request
  */
 @XStreamAlias("apache-http-add-date-to-request")
+@NoArgsConstructor
 public class DateHeader implements RequestInterceptorBuilder {
 
   @Override

--- a/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/RemoveHeaders.java
+++ b/interlok-apache-http/src/main/java/com/adaptris/core/http/apache/request/RemoveHeaders.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,20 +15,16 @@
 */
 package com.adaptris.core.http.apache.request;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
-
 import com.adaptris.annotation.AutoPopulated;
-import com.adaptris.core.util.Args;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.http.HttpRequestInterceptor;
 
 /**
  * Remove headers from the outgoing request.
@@ -36,23 +32,22 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * This is included for completeness; you might, for instance, want to remove the {@code User-Agent} header to avoid being
  * identified as Apache-HTTP...
  * </p>
- * 
+ *
  * @config apache-http-remove-headers
  */
 @XStreamAlias("apache-http-remove-headers")
+@NoArgsConstructor
 public class RemoveHeaders implements RequestInterceptorBuilder {
 
   @XStreamImplicit(itemFieldName = "header")
-  @NotNull
+  @NotNull(message="list of headers may not be null, use an empty list")
   @AutoPopulated
-  private List<String> headers;
-
-  public RemoveHeaders() {
-    setHeaders(new ArrayList());
-  }
+  @Getter
+  @Setter
+  private List<String> headers = new ArrayList<>();
 
   public RemoveHeaders(String... list) {
-    this(new ArrayList<String>(Arrays.asList(list)));
+    this(new ArrayList<>(List.of(list)));
   }
 
   public RemoveHeaders(List<String> list) {
@@ -60,21 +55,11 @@ public class RemoveHeaders implements RequestInterceptorBuilder {
     setHeaders(list);
   }
 
-  public List<String> getHeaders() {
-    return headers;
-  }
-
-  public void setHeaders(List<String> list) {
-    this.headers = Args.notNull(list, "headers");
-  }
-
   @Override
   public HttpRequestInterceptor build() {
-    return new HttpRequestInterceptor() {
-      public void process(HttpRequest request, HttpContext context) {
-        for (String hdr : getHeaders()) {
-          request.removeHeaders(hdr);
-        }
+    return (request, context) -> {
+      for (String hdr : getHeaders()) {
+        request.removeHeaders(hdr);
       }
     };
   }

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ClientBuilderWithCredentials.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/ClientBuilderWithCredentials.java
@@ -6,6 +6,7 @@ import com.adaptris.core.http.apache.HttpClientBuilderConfigurator;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import interlok.http.apache.credentials.CredentialsProviderBuilder;
 import java.util.Optional;
+import javax.validation.Valid;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -35,6 +36,7 @@ public class ClientBuilderWithCredentials implements HttpClientBuilderConfigurat
    */
   @Getter
   @Setter
+  @Valid
   private CredentialsProviderBuilder credentialsProvider;
 
   @Override

--- a/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
+++ b/interlok-apache-http/src/main/java/interlok/http/apache/credentials/DefaultCredentialsProviderBuilder.java
@@ -5,6 +5,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import java.util.ArrayList;
 import java.util.List;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,6 +33,7 @@ public class DefaultCredentialsProviderBuilder implements CredentialsProviderBui
   @NonNull
   @NotNull(message = "No Credentials associated with a CredentialsProvider")
   @XStreamImplicit(itemFieldName = "scoped-credential")
+  @Valid
   private List<ScopedCredential> scopedCredentials = new ArrayList<>();
 
   public DefaultCredentialsProviderBuilder withScopedCredentials(ScopedCredential... w) {

--- a/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
+++ b/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/ApacheHttpProducerTest.java
@@ -14,6 +14,7 @@ import static com.adaptris.core.http.apache.JettyHelper.stopAndRelease;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -95,14 +96,8 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
   @Test
   public void testSetRequestHandler() throws Exception {
     ApacheHttpProducer p = new ApacheHttpProducer();
-    assertEquals(NoOpRequestHeaders.class, p.getRequestHeaderProvider().getClass());
-    try {
-      p.setRequestHeaderProvider(null);
-      fail();
-    } catch (Exception expected) {
-
-    }
-    assertEquals(NoOpRequestHeaders.class, p.getRequestHeaderProvider().getClass());
+    assertNull(p.getRequestHeaderProvider());
+    assertEquals(NoOpRequestHeaders.class, p.requestHeaderProvider().getClass());
     p.setRequestHeaderProvider(new MetadataRequestHeaders(new RemoveAllMetadataFilter()));
     assertEquals(MetadataRequestHeaders.class, p.getRequestHeaderProvider().getClass());
   }
@@ -111,14 +106,8 @@ public class ApacheHttpProducerTest extends ExampleProducerCase {
   @Test
   public void testSetResponseHandler() throws Exception {
     ApacheHttpProducer p = new ApacheHttpProducer();
-    assertEquals(DiscardResponseHeaders.class, p.getResponseHeaderHandler().getClass());
-    try {
-      p.setResponseHeaderHandler(null);
-      fail();
-    } catch (Exception expected) {
-
-    }
-    assertEquals(DiscardResponseHeaders.class, p.getResponseHeaderHandler().getClass());
+    assertNull(p.getResponseHeaderHandler());
+    assertEquals(DiscardResponseHeaders.class, p.responseHeaderHandler().getClass());
     p.setResponseHeaderHandler(new ResponseHeadersAsMetadata());
     assertEquals(ResponseHeadersAsMetadata.class, p.getResponseHeaderHandler().getClass());
   }

--- a/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/MetadataRequestHeadersTest.java
+++ b/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/MetadataRequestHeadersTest.java
@@ -3,18 +3,17 @@ package com.adaptris.core.http.apache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.adaptris.core.metadata.RemoveAllMetadataFilter;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MetadataRequestHeadersTest extends RequestHeadersCase {
 
@@ -28,14 +27,8 @@ public class MetadataRequestHeadersTest extends RequestHeadersCase {
   public void testFilter() throws Exception {
     MetadataRequestHeaders headers = new MetadataRequestHeaders();
     assertNull(headers.getFilter());
+    assertEquals(RemoveAllMetadataFilter.class, headers.filter().getClass());
     headers.setFilter(new NoOpMetadataFilter());
-    assertEquals(NoOpMetadataFilter.class, headers.getFilter().getClass());
-    try {
-      headers.setFilter(null);
-      fail();
-    } catch (IllegalArgumentException expected) {
-
-    }
     assertEquals(NoOpMetadataFilter.class, headers.getFilter().getClass());
   }
 
@@ -50,7 +43,5 @@ public class MetadataRequestHeadersTest extends RequestHeadersCase {
     httpOperation = headers.addHeaders(msg, httpOperation);
     assertTrue(contains(httpOperation, name, name));
   }
-
-
 
 }

--- a/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/request/BasicHmacSignatureTest.java
+++ b/interlok-apache-http/src/test/java/com/adaptris/core/http/apache/request/BasicHmacSignatureTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.adaptris.core.http.HttpConstants;
+import com.adaptris.core.http.apache.request.HMACSignatureImpl.Algorithm;
+import com.adaptris.core.http.apache.request.HMACSignatureImpl.Encoding;
+import com.adaptris.security.exc.PasswordException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.protocol.HttpDateGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.adaptris.core.http.HttpConstants;
-import com.adaptris.core.http.apache.request.HMACSignatureImpl.Algorithm;
-import com.adaptris.core.http.apache.request.HMACSignatureImpl.Encoding;
 
 public class BasicHmacSignatureTest {
 
@@ -58,19 +58,19 @@ public class BasicHmacSignatureTest {
   @Test
   public void testAlgorithm() {
     BasicHMACSignature hmac = new BasicHMACSignature();
-    assertNotNull(hmac.getHmacAlgorithm());
-    assertEquals(HMACSignatureImpl.Algorithm.HMAC_SHA256, hmac.getHmacAlgorithm());
+    assertNull(hmac.getHmacAlgorithm());
+    assertEquals(HMACSignatureImpl.Algorithm.HMAC_SHA256, hmac.hmacAlgorithm());
     hmac.withHmacAlgorithm(Algorithm.HMAC_MD5);
-    assertEquals(HMACSignatureImpl.Algorithm.HMAC_MD5, hmac.getHmacAlgorithm());
+    assertEquals(HMACSignatureImpl.Algorithm.HMAC_MD5, hmac.hmacAlgorithm());
   }
 
   @Test
   public void testEncoding() {
     BasicHMACSignature hmac = new BasicHMACSignature();
-    assertNotNull(hmac.getEncoding());
-    assertEquals(HMACSignatureImpl.Encoding.BASE64, hmac.getEncoding());
+    assertNull(hmac.getEncoding());
+    assertEquals(HMACSignatureImpl.Encoding.BASE64, hmac.encoding());
     hmac.withEncoding(HMACSignatureImpl.Encoding.HEX);
-    assertEquals(HMACSignatureImpl.Encoding.HEX, hmac.getEncoding());
+    assertEquals(HMACSignatureImpl.Encoding.HEX, hmac.encoding());
   }
 
   @Test
@@ -88,7 +88,7 @@ public class BasicHmacSignatureTest {
     assertEquals("hmac", hmac.targetHeader());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test(expected = PasswordException.class)
   public void testSecretKey() {
     BasicHMACSignature hmac = new BasicHMACSignature();
     assertNull(hmac.getSecretKey());


### PR DESCRIPTION
## Motivation

Reviewing the annotations for the interlok-apache-http (v4) project, since there is XML clutter.

## Modification

- Add UI Validation annotations
- Where they have sensible default remove @NotNull annotations with a new method which provides the default via defaultIfNull
- Remove tests where we explicitly test for Args.notNull behaviour

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

No change for the user at runtime, friendlier messages when they don't obey the validation constraints.

## Testing

Unit-tests still pass, and it has been largely a case of removing getters & setters.
Since there have been minimal changes to unit-tests, I have every expectation things will work as desired.
